### PR TITLE
Add Megatron `.bin` file sharding and unsharding scripts

### DIFF
--- a/utils/shard_memmap.py
+++ b/utils/shard_memmap.py
@@ -1,0 +1,61 @@
+import os
+import argparse
+
+import numpy as np
+from tqdm import tqdm
+
+
+def shard(
+    input_file: str,
+    output_dir: str,
+):
+    """Shard a Megatron .bin file into ~ 9 GB chunks"""
+    SHARD_SIZE = 10_000_000_000 # bytes ~= 9 GB 
+    
+    # load in memmapped .bin file
+    full_idx_map = np.memmap(input_file, mode="r", order="C")
+
+    # get number of chunks (rounds down bc start counting from shard number 0)
+    num_chunks = full_idx_map.shape[0] // SHARD_SIZE
+
+    # chunk by iterating over file
+    for i in tqdm(range(num_chunks + 1)): # while still have file contents remaining to chunk:
+        
+        start_idx = i * SHARD_SIZE
+        end_idx = (i + 1) * SHARD_SIZE
+
+        if end_idx > full_idx_map.shape[0]:
+            chunk = full_idx_map[start_idx:]
+        else:
+            chunk = full_idx_map[start_idx:end_idx]
+
+        shard_filename = os.path.join(output_dir, os.path.basename(input_file)[:-4]) + f"-{i:05}-of-{num_chunks:05}.bin"
+        with open(shard_filename, "wb+") as out_shard_file:
+            print(f"Dumping shard {i:05} to {shard_filename} ...")
+            chunk.tofile(out_shard_file)
+
+        del chunk
+
+
+if __name__ == "__main__":
+    
+    parser = argparse.ArgumentParser(
+        description="Shard a single Megatron data .bin file"
+    )
+
+    ## CLI args
+    parser.add_argument(
+        "--input_file",
+        type=str,
+        help="Path to .bin file e.g. /path/to/pile_0.87_deduped_text_document.bin",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        help="Folder to save shards into",
+    )
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    shard(args.input_file, args.output_dir)

--- a/utils/shard_memmap.py
+++ b/utils/shard_memmap.py
@@ -9,8 +9,8 @@ def shard(
     input_file: str,
     output_dir: str,
 ):
-    """Shard a Megatron .bin file into ~ 9 GB chunks"""
-    SHARD_SIZE = 10_000_000_000 # bytes ~= 9 GB 
+    """Shard a Megatron .bin file into ~ 4.5 GB chunks"""
+    SHARD_SIZE = 5_000_000_000 # bytes ~= 4.5 GB 
     
     # load in memmapped .bin file
     full_idx_map = np.memmap(input_file, mode="r", order="C")

--- a/utils/unshard_memmap.py
+++ b/utils/unshard_memmap.py
@@ -1,0 +1,65 @@
+import os
+import argparse
+
+import numpy as np
+from tqdm import tqdm
+
+
+def unshard(
+    input_file: str,
+    num_shards: int,
+    output_dir: str,
+):
+    """Reconstruct a Megatron .bin file from shards""" 
+    
+    input_dir = os.path.dirname(input_file)
+    base_filename = os.path.basename(input_file)[:-19] # remove 00000-of-xxxxx.bin suffix from shard 0's filename
+
+    full_idx_map = None
+
+    # chunk by iterating over file
+    print(f"Loading {num_shards} shards from {input_dir}")
+    for i in tqdm(range(num_shards)):
+        
+        shard_filename = os.path.join(input_dir, base_filename) + f"-{i:05}-of-{(num_shards - 1):05}.bin"
+        print(shard_filename)
+        shard_memmap = np.memmap(shard_filename, mode="r", order="C")
+
+        if not full_idx_map:
+            full_idx_map = shard_memmap
+        else:    
+            np.concatenate([full_idx_map, shard_memmap])
+
+    
+    # write full file
+    with open(os.path.join(output_dir, base_filename) + ".bin", "wb+") as out_full_file:
+        full_idx_map.tofile(out_full_file)
+
+
+if __name__ == "__main__":
+    
+    parser = argparse.ArgumentParser(
+        description="Shard a single Megatron data .bin file"
+    )
+
+    ## CLI args
+    parser.add_argument(
+        "--input_file",
+        type=str,
+        help="Path to shard 0",
+    )
+    parser.add_argument(
+        "--num_shards",
+        type=int,
+        help="Provide number of shards (The total seen in shard filenames)"
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        help="Folder to save .bin file into",
+    )
+    args = parser.parse_args()
+    
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    unshard(args.input_file, args.num_shards, args.output_dir)

--- a/utils/unshard_memmap.py
+++ b/utils/unshard_memmap.py
@@ -11,11 +11,15 @@ def unshard(
     output_dir: str,
 ):
     """Reconstruct a Megatron .bin file from shards""" 
-    
+    SHARD_SIZE = 5_000_000_000
+
     input_dir = os.path.dirname(input_file)
     base_filename = os.path.basename(input_file)[:-19] # remove 00000-of-xxxxx.bin suffix from shard 0's filename
+    
 
-    full_idx_map = None
+    open(os.path.join(output_dir, base_filename) + ".bin", "w+").close()
+    full_idx_map = np.memmap(os.path.join(output_dir, base_filename) + ".bin", shape=(num_shards * SHARD_SIZE,), mode="w+", order="C")
+    print(full_idx_map.shape)
 
     # chunk by iterating over file
     print(f"Loading {num_shards} shards from {input_dir}")
@@ -25,11 +29,15 @@ def unshard(
         print(shard_filename)
         shard_memmap = np.memmap(shard_filename, mode="r", order="C")
 
-        if not full_idx_map:
-            full_idx_map = shard_memmap
-        else:    
-            np.concatenate([full_idx_map, shard_memmap])
+        #if full_idx_map is None:
+        #    full_idx_map = shard_memmap
+        #else:
+        #    full_idx_map = np.concatenate([full_idx_map, shard_memmap])
+        
+        full_idx_map[i * SHARD_SIZE: (i + 1) * SHARD_SIZE] = shard_memmap
 
+        del shard_memmap
+        print(full_idx_map.shape)
     
     # write full file
     with open(os.path.join(output_dir, base_filename) + ".bin", "wb+") as out_full_file:
@@ -51,7 +59,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--num_shards",
         type=int,
-        help="Provide number of shards (The total seen in shard filenames)"
+        help="Provide number of shards (The total seen in shard filenames + 1)"
     )
     parser.add_argument(
         "--output_dir",

--- a/utils/unshard_memmap.py
+++ b/utils/unshard_memmap.py
@@ -35,20 +35,10 @@ def unshard(
         print(shard_filename)
         shard_memmap = np.memmap(shard_filename, mode="r", order="C")
 
-        #if full_idx_map is None:
-        #    full_idx_map = shard_memmap
-        #else:
-        #    full_idx_map = np.concatenate([full_idx_map, shard_memmap])
         size = SHARD_SIZE if not (i == num_shards - 1) else final_shard_size
         full_idx_map[i * SHARD_SIZE: (i * SHARD_SIZE) + size] = shard_memmap
 
         del shard_memmap
-        print(full_idx_map.shape)
-    
-    # write full file
-    with open(os.path.join(output_dir, base_filename) + ".bin", "wb+") as out_full_file:
-        full_idx_map.tofile(out_full_file)
-
 
 if __name__ == "__main__":
     


### PR DESCRIPTION
Intended to close #15 .

2 utilities to shard + unshard a `.bin` file. These should be usable already (tested with Enron) and shouldn't load any files into memory naively, but will test on Pile shortly. 

Checklist
- [x] Write scripts
- [x] Test with Pile data
- [ ] Write README section on how to use (include instructions to self-tokenize as well)
- [x] Actually shard + upload both datasets to HF 