### PR TITLE
Add BLOOM evaluations through 7.1B

### DIFF
--- a/results/bloom/bloom-1b1.json
+++ b/results/bloom/bloom-1b1.json
@@ -1,0 +1,468 @@
+{
+  "results": {
+    "hendrycksTest-us_foreign_policy": {
+      "acc": 0.31,
+      "acc_stderr": 0.04648231987117316,
+      "acc_norm": 0.3,
+      "acc_norm_stderr": 0.046056618647183814
+    },
+    "hendrycksTest-philosophy": {
+      "acc": 0.21543408360128619,
+      "acc_stderr": 0.023350225475471418,
+      "acc_norm": 0.3022508038585209,
+      "acc_norm_stderr": 0.026082700695399662
+    },
+    "hendrycksTest-human_sexuality": {
+      "acc": 0.2900763358778626,
+      "acc_stderr": 0.03980066246467766,
+      "acc_norm": 0.2900763358778626,
+      "acc_norm_stderr": 0.03980066246467766
+    },
+    "piqa": {
+      "acc": 0.6719260065288357,
+      "acc_stderr": 0.01095448713512424,
+      "acc_norm": 0.6724700761697497,
+      "acc_norm_stderr": 0.010949830482825471
+    },
+    "hendrycksTest-professional_law": {
+      "acc": 0.2561929595827901,
+      "acc_stderr": 0.011149173153110578,
+      "acc_norm": 0.29595827900912647,
+      "acc_norm_stderr": 0.011658518525277042
+    },
+    "hendrycksTest-jurisprudence": {
+      "acc": 0.2222222222222222,
+      "acc_stderr": 0.0401910747255735,
+      "acc_norm": 0.3888888888888889,
+      "acc_norm_stderr": 0.047128212574267705
+    },
+    "hendrycksTest-conceptual_physics": {
+      "acc": 0.2553191489361702,
+      "acc_stderr": 0.028504856470514192,
+      "acc_norm": 0.20425531914893616,
+      "acc_norm_stderr": 0.026355158413349417
+    },
+    "hendrycksTest-high_school_macroeconomics": {
+      "acc": 0.258974358974359,
+      "acc_stderr": 0.022211106810061672,
+      "acc_norm": 0.24102564102564103,
+      "acc_norm_stderr": 0.021685546665333198
+    },
+    "logiqa": {
+      "acc": 0.1889400921658986,
+      "acc_stderr": 0.01535436463822078,
+      "acc_norm": 0.25806451612903225,
+      "acc_norm_stderr": 0.017162894755127063
+    },
+    "hendrycksTest-machine_learning": {
+      "acc": 0.33035714285714285,
+      "acc_stderr": 0.044642857142857144,
+      "acc_norm": 0.30357142857142855,
+      "acc_norm_stderr": 0.04364226155841044
+    },
+    "hendrycksTest-medical_genetics": {
+      "acc": 0.28,
+      "acc_stderr": 0.04512608598542128,
+      "acc_norm": 0.4,
+      "acc_norm_stderr": 0.049236596391733084
+    },
+    "hendrycksTest-nutrition": {
+      "acc": 0.2908496732026144,
+      "acc_stderr": 0.02600480036395211,
+      "acc_norm": 0.38235294117647056,
+      "acc_norm_stderr": 0.027826109307283693
+    },
+    "hendrycksTest-virology": {
+      "acc": 0.3855421686746988,
+      "acc_stderr": 0.037891344246115496,
+      "acc_norm": 0.3433734939759036,
+      "acc_norm_stderr": 0.03696584317010601
+    },
+    "hendrycksTest-professional_accounting": {
+      "acc": 0.22695035460992907,
+      "acc_stderr": 0.024987106365642976,
+      "acc_norm": 0.2765957446808511,
+      "acc_norm_stderr": 0.026684564340460997
+    },
+    "hendrycksTest-elementary_mathematics": {
+      "acc": 0.24338624338624337,
+      "acc_stderr": 0.022101128787415436,
+      "acc_norm": 0.2619047619047619,
+      "acc_norm_stderr": 0.02264421261552521
+    },
+    "hendrycksTest-high_school_geography": {
+      "acc": 0.20707070707070707,
+      "acc_stderr": 0.028869778460267042,
+      "acc_norm": 0.2828282828282828,
+      "acc_norm_stderr": 0.03208779558786752
+    },
+    "hendrycksTest-high_school_biology": {
+      "acc": 0.18387096774193548,
+      "acc_stderr": 0.022037217340267846,
+      "acc_norm": 0.27741935483870966,
+      "acc_norm_stderr": 0.025470196835900055
+    },
+    "hendrycksTest-logical_fallacies": {
+      "acc": 0.19631901840490798,
+      "acc_stderr": 0.031207970394709215,
+      "acc_norm": 0.2822085889570552,
+      "acc_norm_stderr": 0.03536117886664743
+    },
+    "hendrycksTest-high_school_mathematics": {
+      "acc": 0.21481481481481482,
+      "acc_stderr": 0.025040443877000683,
+      "acc_norm": 0.2777777777777778,
+      "acc_norm_stderr": 0.02730914058823018
+    },
+    "hendrycksTest-high_school_microeconomics": {
+      "acc": 0.21008403361344538,
+      "acc_stderr": 0.026461398717471874,
+      "acc_norm": 0.31932773109243695,
+      "acc_norm_stderr": 0.030283995525884396
+    },
+    "hendrycksTest-moral_disputes": {
+      "acc": 0.25722543352601157,
+      "acc_stderr": 0.023532925431044287,
+      "acc_norm": 0.3265895953757225,
+      "acc_norm_stderr": 0.025248264774242832
+    },
+    "hendrycksTest-professional_medicine": {
+      "acc": 0.19117647058823528,
+      "acc_stderr": 0.023886881922440328,
+      "acc_norm": 0.23529411764705882,
+      "acc_norm_stderr": 0.025767252010855952
+    },
+    "hendrycksTest-public_relations": {
+      "acc": 0.24545454545454545,
+      "acc_stderr": 0.041220665028782855,
+      "acc_norm": 0.24545454545454545,
+      "acc_norm_stderr": 0.04122066502878284
+    },
+    "hendrycksTest-high_school_chemistry": {
+      "acc": 0.22167487684729065,
+      "acc_stderr": 0.029225575892489614,
+      "acc_norm": 0.28078817733990147,
+      "acc_norm_stderr": 0.03161856335358609
+    },
+    "hendrycksTest-security_studies": {
+      "acc": 0.34285714285714286,
+      "acc_stderr": 0.03038726291954772,
+      "acc_norm": 0.2897959183673469,
+      "acc_norm_stderr": 0.029043088683304328
+    },
+    "hendrycksTest-miscellaneous": {
+      "acc": 0.25287356321839083,
+      "acc_stderr": 0.01554337731371968,
+      "acc_norm": 0.24776500638569604,
+      "acc_norm_stderr": 0.015438083080568961
+    },
+    "hendrycksTest-computer_security": {
+      "acc": 0.26,
+      "acc_stderr": 0.04408440022768079,
+      "acc_norm": 0.32,
+      "acc_norm_stderr": 0.046882617226215034
+    },
+    "hendrycksTest-formal_logic": {
+      "acc": 0.30952380952380953,
+      "acc_stderr": 0.04134913018303317,
+      "acc_norm": 0.3333333333333333,
+      "acc_norm_stderr": 0.04216370213557835
+    },
+    "hendrycksTest-college_chemistry": {
+      "acc": 0.22,
+      "acc_stderr": 0.04163331998932269,
+      "acc_norm": 0.29,
+      "acc_norm_stderr": 0.045604802157206845
+    },
+    "hendrycksTest-high_school_us_history": {
+      "acc": 0.25980392156862747,
+      "acc_stderr": 0.030778554678693257,
+      "acc_norm": 0.24019607843137256,
+      "acc_norm_stderr": 0.02998373305591361
+    },
+    "hendrycksTest-astronomy": {
+      "acc": 0.21052631578947367,
+      "acc_stderr": 0.033176727875331574,
+      "acc_norm": 0.34210526315789475,
+      "acc_norm_stderr": 0.03860731599316092
+    },
+    "hendrycksTest-anatomy": {
+      "acc": 0.17777777777777778,
+      "acc_stderr": 0.03302789859901718,
+      "acc_norm": 0.21481481481481482,
+      "acc_norm_stderr": 0.035478541985608264
+    },
+    "hendrycksTest-global_facts": {
+      "acc": 0.23,
+      "acc_stderr": 0.04229525846816507,
+      "acc_norm": 0.25,
+      "acc_norm_stderr": 0.04351941398892446
+    },
+    "winogrande": {
+      "acc": 0.5469613259668509,
+      "acc_stderr": 0.0139903666321481
+    },
+    "hendrycksTest-high_school_world_history": {
+      "acc": 0.26582278481012656,
+      "acc_stderr": 0.02875679962965834,
+      "acc_norm": 0.2742616033755274,
+      "acc_norm_stderr": 0.029041333510598028
+    },
+    "hendrycksTest-college_medicine": {
+      "acc": 0.23121387283236994,
+      "acc_stderr": 0.03214737302029468,
+      "acc_norm": 0.24855491329479767,
+      "acc_norm_stderr": 0.03295304696818318
+    },
+    "hendrycksTest-moral_scenarios": {
+      "acc": 0.23798882681564246,
+      "acc_stderr": 0.014242630070574915,
+      "acc_norm": 0.28044692737430166,
+      "acc_norm_stderr": 0.015024083883322902
+    },
+    "hendrycksTest-management": {
+      "acc": 0.21359223300970873,
+      "acc_stderr": 0.04058042015646034,
+      "acc_norm": 0.22330097087378642,
+      "acc_norm_stderr": 0.04123553189891431
+    },
+    "hendrycksTest-prehistory": {
+      "acc": 0.24382716049382716,
+      "acc_stderr": 0.023891879541959607,
+      "acc_norm": 0.21604938271604937,
+      "acc_norm_stderr": 0.022899162918445803
+    },
+    "hendrycksTest-high_school_physics": {
+      "acc": 0.17218543046357615,
+      "acc_stderr": 0.03082613696196237,
+      "acc_norm": 0.2119205298013245,
+      "acc_norm_stderr": 0.033367670865679766
+    },
+    "hendrycksTest-high_school_computer_science": {
+      "acc": 0.22,
+      "acc_stderr": 0.041633319989322716,
+      "acc_norm": 0.24,
+      "acc_norm_stderr": 0.04292346959909284
+    },
+    "hendrycksTest-abstract_algebra": {
+      "acc": 0.19,
+      "acc_stderr": 0.03942772444036624,
+      "acc_norm": 0.26,
+      "acc_norm_stderr": 0.0440844002276808
+    },
+    "sciq": {
+      "acc": 0.833,
+      "acc_stderr": 0.011800434324644588,
+      "acc_norm": 0.742,
+      "acc_norm_stderr": 0.013842963108656603
+    },
+    "arc_easy": {
+      "acc": 0.5147306397306397,
+      "acc_stderr": 0.010255329977562096,
+      "acc_norm": 0.45454545454545453,
+      "acc_norm_stderr": 0.010217299762709435
+    },
+    "lambada_openai": {
+      "ppl": 17.283788767560942,
+      "ppl_stderr": 0.5852985311942187,
+      "acc": 0.42577139530370656,
+      "acc_stderr": 0.006888786490936478
+    },
+    "arc_challenge": {
+      "acc": 0.2363481228668942,
+      "acc_stderr": 0.012414960524301834,
+      "acc_norm": 0.2568259385665529,
+      "acc_norm_stderr": 0.0127669237941168
+    },
+    "hendrycksTest-high_school_european_history": {
+      "acc": 0.23030303030303031,
+      "acc_stderr": 0.03287666758603488,
+      "acc_norm": 0.296969696969697,
+      "acc_norm_stderr": 0.03567969772268048
+    },
+    "hendrycksTest-high_school_government_and_politics": {
+      "acc": 0.20725388601036268,
+      "acc_stderr": 0.029252823291803627,
+      "acc_norm": 0.23834196891191708,
+      "acc_norm_stderr": 0.030748905363909895
+    },
+    "hendrycksTest-high_school_psychology": {
+      "acc": 0.1908256880733945,
+      "acc_stderr": 0.016847676400091095,
+      "acc_norm": 0.2036697247706422,
+      "acc_norm_stderr": 0.01726674208763079
+    },
+    "hendrycksTest-human_aging": {
+      "acc": 0.3094170403587444,
+      "acc_stderr": 0.03102441174057221,
+      "acc_norm": 0.24663677130044842,
+      "acc_norm_stderr": 0.028930413120910877
+    },
+    "hendrycksTest-marketing": {
+      "acc": 0.32905982905982906,
+      "acc_stderr": 0.030782321577688156,
+      "acc_norm": 0.34615384615384615,
+      "acc_norm_stderr": 0.0311669573672359
+    },
+    "hendrycksTest-world_religions": {
+      "acc": 0.28654970760233917,
+      "acc_stderr": 0.03467826685703826,
+      "acc_norm": 0.3567251461988304,
+      "acc_norm_stderr": 0.03674013002860954
+    },
+    "hendrycksTest-international_law": {
+      "acc": 0.23140495867768596,
+      "acc_stderr": 0.03849856098794088,
+      "acc_norm": 0.3884297520661157,
+      "acc_norm_stderr": 0.04449270350068382
+    },
+    "hendrycksTest-professional_psychology": {
+      "acc": 0.2679738562091503,
+      "acc_stderr": 0.017917974069594726,
+      "acc_norm": 0.2761437908496732,
+      "acc_norm_stderr": 0.018087276935663137
+    },
+    "hendrycksTest-business_ethics": {
+      "acc": 0.34,
+      "acc_stderr": 0.04760952285695235,
+      "acc_norm": 0.31,
+      "acc_norm_stderr": 0.04648231987117316
+    },
+    "hendrycksTest-high_school_statistics": {
+      "acc": 0.20833333333333334,
+      "acc_stderr": 0.027696910713093933,
+      "acc_norm": 0.2777777777777778,
+      "acc_norm_stderr": 0.030546745264953185
+    },
+    "wsc": {
+      "acc": 0.36538461538461536,
+      "acc_stderr": 0.0474473339327792
+    },
+    "hendrycksTest-clinical_knowledge": {
+      "acc": 0.2641509433962264,
+      "acc_stderr": 0.02713429162874171,
+      "acc_norm": 0.30943396226415093,
+      "acc_norm_stderr": 0.028450154794118627
+    },
+    "hendrycksTest-college_biology": {
+      "acc": 0.24305555555555555,
+      "acc_stderr": 0.0358687928008034,
+      "acc_norm": 0.2569444444444444,
+      "acc_norm_stderr": 0.03653946969442099
+    },
+    "hendrycksTest-sociology": {
+      "acc": 0.2835820895522388,
+      "acc_stderr": 0.031871875379197966,
+      "acc_norm": 0.31343283582089554,
+      "acc_norm_stderr": 0.032801882053486435
+    },
+    "hendrycksTest-electrical_engineering": {
+      "acc": 0.2827586206896552,
+      "acc_stderr": 0.03752833958003336,
+      "acc_norm": 0.2827586206896552,
+      "acc_norm_stderr": 0.037528339580033376
+    },
+    "hendrycksTest-college_physics": {
+      "acc": 0.24509803921568626,
+      "acc_stderr": 0.04280105837364395,
+      "acc_norm": 0.30392156862745096,
+      "acc_norm_stderr": 0.045766654032077615
+    },
+    "hendrycksTest-college_computer_science": {
+      "acc": 0.25,
+      "acc_stderr": 0.04351941398892446,
+      "acc_norm": 0.21,
+      "acc_norm_stderr": 0.040936018074033256
+    },
+    "hendrycksTest-econometrics": {
+      "acc": 0.2543859649122807,
+      "acc_stderr": 0.04096985139843671,
+      "acc_norm": 0.18421052631578946,
+      "acc_norm_stderr": 0.03646758875075566
+    },
+    "hendrycksTest-college_mathematics": {
+      "acc": 0.25,
+      "acc_stderr": 0.04351941398892446,
+      "acc_norm": 0.32,
+      "acc_norm_stderr": 0.046882617226215034
+    }
+  },
+  "versions": {
+    "hendrycksTest-us_foreign_policy": 0,
+    "hendrycksTest-philosophy": 0,
+    "hendrycksTest-human_sexuality": 0,
+    "piqa": 0,
+    "hendrycksTest-professional_law": 0,
+    "hendrycksTest-jurisprudence": 0,
+    "hendrycksTest-conceptual_physics": 0,
+    "hendrycksTest-high_school_macroeconomics": 0,
+    "logiqa": 0,
+    "hendrycksTest-machine_learning": 0,
+    "hendrycksTest-medical_genetics": 0,
+    "hendrycksTest-nutrition": 0,
+    "hendrycksTest-virology": 0,
+    "hendrycksTest-professional_accounting": 0,
+    "hendrycksTest-elementary_mathematics": 0,
+    "hendrycksTest-high_school_geography": 0,
+    "hendrycksTest-high_school_biology": 0,
+    "hendrycksTest-logical_fallacies": 0,
+    "hendrycksTest-high_school_mathematics": 0,
+    "hendrycksTest-high_school_microeconomics": 0,
+    "hendrycksTest-moral_disputes": 0,
+    "hendrycksTest-professional_medicine": 0,
+    "hendrycksTest-public_relations": 0,
+    "hendrycksTest-high_school_chemistry": 0,
+    "hendrycksTest-security_studies": 0,
+    "hendrycksTest-miscellaneous": 0,
+    "hendrycksTest-computer_security": 0,
+    "hendrycksTest-formal_logic": 0,
+    "hendrycksTest-college_chemistry": 0,
+    "hendrycksTest-high_school_us_history": 0,
+    "hendrycksTest-astronomy": 0,
+    "hendrycksTest-anatomy": 0,
+    "hendrycksTest-global_facts": 0,
+    "winogrande": 0,
+    "hendrycksTest-high_school_world_history": 0,
+    "hendrycksTest-college_medicine": 0,
+    "hendrycksTest-moral_scenarios": 0,
+    "hendrycksTest-management": 0,
+    "hendrycksTest-prehistory": 0,
+    "hendrycksTest-high_school_physics": 0,
+    "hendrycksTest-high_school_computer_science": 0,
+    "hendrycksTest-abstract_algebra": 0,
+    "sciq": 0,
+    "arc_easy": 0,
+    "lambada_openai": 0,
+    "arc_challenge": 0,
+    "hendrycksTest-high_school_european_history": 0,
+    "hendrycksTest-high_school_government_and_politics": 0,
+    "hendrycksTest-high_school_psychology": 0,
+    "hendrycksTest-human_aging": 0,
+    "hendrycksTest-marketing": 0,
+    "hendrycksTest-world_religions": 0,
+    "hendrycksTest-international_law": 0,
+    "hendrycksTest-professional_psychology": 0,
+    "hendrycksTest-business_ethics": 0,
+    "hendrycksTest-high_school_statistics": 0,
+    "wsc": 0,
+    "hendrycksTest-clinical_knowledge": 0,
+    "hendrycksTest-college_biology": 0,
+    "hendrycksTest-sociology": 0,
+    "hendrycksTest-electrical_engineering": 0,
+    "hendrycksTest-college_physics": 0,
+    "hendrycksTest-college_computer_science": 0,
+    "hendrycksTest-econometrics": 0,
+    "hendrycksTest-college_mathematics": 0
+  },
+  "config": {
+    "model": "hf-causal",
+    "model_args": "pretrained=bigscience/bloom-1b1,use_accelerate=True,device_map_option=sequential,max_memory_per_gpu=40GIB",
+    "num_fewshot": 0,
+    "batch_size": 8,
+    "device": "cuda",
+    "no_cache": false,
+    "limit": null,
+    "bootstrap_iters": 100000,
+    "description_dict": {}
+  }
+}

--- a/results/bloom/bloom-1b7.json
+++ b/results/bloom/bloom-1b7.json
@@ -1,0 +1,468 @@
+{
+  "results": {
+    "sciq": {
+      "acc": 0.851,
+      "acc_stderr": 0.011266140684632168,
+      "acc_norm": 0.77,
+      "acc_norm_stderr": 0.01331455133593595
+    },
+    "hendrycksTest-nutrition": {
+      "acc": 0.24836601307189543,
+      "acc_stderr": 0.024739981355113596,
+      "acc_norm": 0.35947712418300654,
+      "acc_norm_stderr": 0.027475969910660952
+    },
+    "logiqa": {
+      "acc": 0.21658986175115208,
+      "acc_stderr": 0.016156860583178303,
+      "acc_norm": 0.28110599078341014,
+      "acc_norm_stderr": 0.017632374626460005
+    },
+    "hendrycksTest-moral_disputes": {
+      "acc": 0.2543352601156069,
+      "acc_stderr": 0.023445826276545543,
+      "acc_norm": 0.3179190751445087,
+      "acc_norm_stderr": 0.025070713719153176
+    },
+    "hendrycksTest-jurisprudence": {
+      "acc": 0.23148148148148148,
+      "acc_stderr": 0.04077494709252626,
+      "acc_norm": 0.42592592592592593,
+      "acc_norm_stderr": 0.0478034362693679
+    },
+    "hendrycksTest-public_relations": {
+      "acc": 0.22727272727272727,
+      "acc_stderr": 0.04013964554072774,
+      "acc_norm": 0.20909090909090908,
+      "acc_norm_stderr": 0.038950910157241385
+    },
+    "hendrycksTest-high_school_computer_science": {
+      "acc": 0.25,
+      "acc_stderr": 0.04351941398892446,
+      "acc_norm": 0.29,
+      "acc_norm_stderr": 0.04560480215720684
+    },
+    "hendrycksTest-college_medicine": {
+      "acc": 0.2254335260115607,
+      "acc_stderr": 0.03186209851641143,
+      "acc_norm": 0.24855491329479767,
+      "acc_norm_stderr": 0.03295304696818318
+    },
+    "hendrycksTest-abstract_algebra": {
+      "acc": 0.23,
+      "acc_stderr": 0.04229525846816507,
+      "acc_norm": 0.23,
+      "acc_norm_stderr": 0.04229525846816505
+    },
+    "hendrycksTest-human_sexuality": {
+      "acc": 0.2748091603053435,
+      "acc_stderr": 0.03915345408847837,
+      "acc_norm": 0.2748091603053435,
+      "acc_norm_stderr": 0.03915345408847835
+    },
+    "hendrycksTest-professional_medicine": {
+      "acc": 0.20955882352941177,
+      "acc_stderr": 0.02472311040767705,
+      "acc_norm": 0.22794117647058823,
+      "acc_norm_stderr": 0.0254830814680298
+    },
+    "hendrycksTest-econometrics": {
+      "acc": 0.22807017543859648,
+      "acc_stderr": 0.03947152782669415,
+      "acc_norm": 0.2543859649122807,
+      "acc_norm_stderr": 0.040969851398436695
+    },
+    "hendrycksTest-miscellaneous": {
+      "acc": 0.2541507024265645,
+      "acc_stderr": 0.015569254692045783,
+      "acc_norm": 0.27458492975734355,
+      "acc_norm_stderr": 0.015959829933084053
+    },
+    "hendrycksTest-college_biology": {
+      "acc": 0.2222222222222222,
+      "acc_stderr": 0.034765901043041336,
+      "acc_norm": 0.20833333333333334,
+      "acc_norm_stderr": 0.03396116205845334
+    },
+    "hendrycksTest-college_computer_science": {
+      "acc": 0.28,
+      "acc_stderr": 0.04512608598542128,
+      "acc_norm": 0.31,
+      "acc_norm_stderr": 0.04648231987117316
+    },
+    "hendrycksTest-global_facts": {
+      "acc": 0.25,
+      "acc_stderr": 0.04351941398892446,
+      "acc_norm": 0.26,
+      "acc_norm_stderr": 0.04408440022768078
+    },
+    "hendrycksTest-international_law": {
+      "acc": 0.2396694214876033,
+      "acc_stderr": 0.03896878985070417,
+      "acc_norm": 0.45454545454545453,
+      "acc_norm_stderr": 0.045454545454545456
+    },
+    "hendrycksTest-management": {
+      "acc": 0.20388349514563106,
+      "acc_stderr": 0.03989139859531772,
+      "acc_norm": 0.20388349514563106,
+      "acc_norm_stderr": 0.039891398595317706
+    },
+    "hendrycksTest-marketing": {
+      "acc": 0.2777777777777778,
+      "acc_stderr": 0.029343114798094476,
+      "acc_norm": 0.32905982905982906,
+      "acc_norm_stderr": 0.030782321577688156
+    },
+    "hendrycksTest-high_school_physics": {
+      "acc": 0.1986754966887417,
+      "acc_stderr": 0.032578473844367746,
+      "acc_norm": 0.23178807947019867,
+      "acc_norm_stderr": 0.03445406271987055
+    },
+    "hendrycksTest-high_school_world_history": {
+      "acc": 0.2869198312236287,
+      "acc_stderr": 0.029443773022594693,
+      "acc_norm": 0.2869198312236287,
+      "acc_norm_stderr": 0.02944377302259469
+    },
+    "hendrycksTest-high_school_psychology": {
+      "acc": 0.20917431192660552,
+      "acc_stderr": 0.017437937173343226,
+      "acc_norm": 0.22201834862385322,
+      "acc_norm_stderr": 0.017818849564796648
+    },
+    "hendrycksTest-high_school_statistics": {
+      "acc": 0.17592592592592593,
+      "acc_stderr": 0.02596742095825853,
+      "acc_norm": 0.2824074074074074,
+      "acc_norm_stderr": 0.030701372111510927
+    },
+    "hendrycksTest-world_religions": {
+      "acc": 0.29239766081871343,
+      "acc_stderr": 0.034886477134579215,
+      "acc_norm": 0.38011695906432746,
+      "acc_norm_stderr": 0.037229657413855394
+    },
+    "hendrycksTest-high_school_geography": {
+      "acc": 0.18181818181818182,
+      "acc_stderr": 0.027479603010538797,
+      "acc_norm": 0.24242424242424243,
+      "acc_norm_stderr": 0.030532892233932046
+    },
+    "hendrycksTest-human_aging": {
+      "acc": 0.29596412556053814,
+      "acc_stderr": 0.03063659134869981,
+      "acc_norm": 0.2556053811659193,
+      "acc_norm_stderr": 0.029275891003969927
+    },
+    "hendrycksTest-machine_learning": {
+      "acc": 0.33035714285714285,
+      "acc_stderr": 0.04464285714285714,
+      "acc_norm": 0.22321428571428573,
+      "acc_norm_stderr": 0.03952301967702511
+    },
+    "piqa": {
+      "acc": 0.6855277475516867,
+      "acc_stderr": 0.010833009065106572,
+      "acc_norm": 0.6980413492927094,
+      "acc_norm_stderr": 0.010711732891588336
+    },
+    "hendrycksTest-high_school_chemistry": {
+      "acc": 0.20689655172413793,
+      "acc_stderr": 0.02850137816789395,
+      "acc_norm": 0.27586206896551724,
+      "acc_norm_stderr": 0.031447125816782426
+    },
+    "hendrycksTest-professional_accounting": {
+      "acc": 0.19148936170212766,
+      "acc_stderr": 0.02347264524794944,
+      "acc_norm": 0.25177304964539005,
+      "acc_norm_stderr": 0.025892151156709405
+    },
+    "hendrycksTest-college_physics": {
+      "acc": 0.23529411764705882,
+      "acc_stderr": 0.042207736591714534,
+      "acc_norm": 0.29411764705882354,
+      "acc_norm_stderr": 0.04533838195929774
+    },
+    "hendrycksTest-college_chemistry": {
+      "acc": 0.26,
+      "acc_stderr": 0.04408440022768077,
+      "acc_norm": 0.29,
+      "acc_norm_stderr": 0.045604802157206845
+    },
+    "hendrycksTest-conceptual_physics": {
+      "acc": 0.2553191489361702,
+      "acc_stderr": 0.0285048564705142,
+      "acc_norm": 0.2170212765957447,
+      "acc_norm_stderr": 0.026947483121496217
+    },
+    "hendrycksTest-high_school_us_history": {
+      "acc": 0.2549019607843137,
+      "acc_stderr": 0.03058759135160425,
+      "acc_norm": 0.25980392156862747,
+      "acc_norm_stderr": 0.030778554678693264
+    },
+    "winogrande": {
+      "acc": 0.5722178374112076,
+      "acc_stderr": 0.013905134013839955
+    },
+    "hendrycksTest-professional_law": {
+      "acc": 0.25749674054758803,
+      "acc_stderr": 0.01116770601490416,
+      "acc_norm": 0.2835723598435463,
+      "acc_norm_stderr": 0.011511900775968325
+    },
+    "hendrycksTest-moral_scenarios": {
+      "acc": 0.23687150837988827,
+      "acc_stderr": 0.01421957078810399,
+      "acc_norm": 0.2446927374301676,
+      "acc_norm_stderr": 0.014378169884098405
+    },
+    "hendrycksTest-professional_psychology": {
+      "acc": 0.25163398692810457,
+      "acc_stderr": 0.017555818091322263,
+      "acc_norm": 0.2696078431372549,
+      "acc_norm_stderr": 0.017952449196987862
+    },
+    "hendrycksTest-electrical_engineering": {
+      "acc": 0.22758620689655173,
+      "acc_stderr": 0.03493950380131183,
+      "acc_norm": 0.2896551724137931,
+      "acc_norm_stderr": 0.03780019230438014
+    },
+    "hendrycksTest-security_studies": {
+      "acc": 0.2938775510204082,
+      "acc_stderr": 0.029162738410249765,
+      "acc_norm": 0.2530612244897959,
+      "acc_norm_stderr": 0.027833023871399683
+    },
+    "hendrycksTest-high_school_microeconomics": {
+      "acc": 0.23109243697478993,
+      "acc_stderr": 0.02738140692786897,
+      "acc_norm": 0.3277310924369748,
+      "acc_norm_stderr": 0.03048991141767323
+    },
+    "hendrycksTest-high_school_macroeconomics": {
+      "acc": 0.26153846153846155,
+      "acc_stderr": 0.022282141204204426,
+      "acc_norm": 0.26666666666666666,
+      "acc_norm_stderr": 0.022421273612923714
+    },
+    "hendrycksTest-high_school_mathematics": {
+      "acc": 0.22962962962962963,
+      "acc_stderr": 0.025644108639267634,
+      "acc_norm": 0.2962962962962963,
+      "acc_norm_stderr": 0.027840811495871927
+    },
+    "hendrycksTest-high_school_european_history": {
+      "acc": 0.2,
+      "acc_stderr": 0.031234752377721175,
+      "acc_norm": 0.23030303030303031,
+      "acc_norm_stderr": 0.032876667586034886
+    },
+    "hendrycksTest-prehistory": {
+      "acc": 0.24382716049382716,
+      "acc_stderr": 0.023891879541959617,
+      "acc_norm": 0.2191358024691358,
+      "acc_norm_stderr": 0.0230167056402622
+    },
+    "hendrycksTest-astronomy": {
+      "acc": 0.23026315789473684,
+      "acc_stderr": 0.03426059424403165,
+      "acc_norm": 0.3223684210526316,
+      "acc_norm_stderr": 0.03803510248351585
+    },
+    "lambada_openai": {
+      "ppl": 12.583803767927781,
+      "ppl_stderr": 0.4021519184938019,
+      "acc": 0.4622549970890743,
+      "acc_stderr": 0.0069461006470815665
+    },
+    "hendrycksTest-high_school_government_and_politics": {
+      "acc": 0.23316062176165803,
+      "acc_stderr": 0.030516111371476008,
+      "acc_norm": 0.2538860103626943,
+      "acc_norm_stderr": 0.0314102478056532
+    },
+    "wsc": {
+      "acc": 0.36538461538461536,
+      "acc_stderr": 0.0474473339327792
+    },
+    "hendrycksTest-computer_security": {
+      "acc": 0.32,
+      "acc_stderr": 0.04688261722621504,
+      "acc_norm": 0.3,
+      "acc_norm_stderr": 0.046056618647183814
+    },
+    "hendrycksTest-college_mathematics": {
+      "acc": 0.24,
+      "acc_stderr": 0.04292346959909283,
+      "acc_norm": 0.3,
+      "acc_norm_stderr": 0.046056618647183814
+    },
+    "hendrycksTest-us_foreign_policy": {
+      "acc": 0.28,
+      "acc_stderr": 0.04512608598542128,
+      "acc_norm": 0.32,
+      "acc_norm_stderr": 0.046882617226215034
+    },
+    "hendrycksTest-anatomy": {
+      "acc": 0.1925925925925926,
+      "acc_stderr": 0.03406542058502653,
+      "acc_norm": 0.21481481481481482,
+      "acc_norm_stderr": 0.035478541985608264
+    },
+    "hendrycksTest-clinical_knowledge": {
+      "acc": 0.2528301886792453,
+      "acc_stderr": 0.02674989977124123,
+      "acc_norm": 0.3132075471698113,
+      "acc_norm_stderr": 0.02854479331905533
+    },
+    "hendrycksTest-formal_logic": {
+      "acc": 0.30158730158730157,
+      "acc_stderr": 0.04104947269903394,
+      "acc_norm": 0.31746031746031744,
+      "acc_norm_stderr": 0.041634530313028585
+    },
+    "hendrycksTest-virology": {
+      "acc": 0.3253012048192771,
+      "acc_stderr": 0.03647168523683226,
+      "acc_norm": 0.29518072289156627,
+      "acc_norm_stderr": 0.0355092018568963
+    },
+    "hendrycksTest-philosophy": {
+      "acc": 0.2057877813504823,
+      "acc_stderr": 0.022961339906764237,
+      "acc_norm": 0.3247588424437299,
+      "acc_norm_stderr": 0.026596782287697046
+    },
+    "hendrycksTest-high_school_biology": {
+      "acc": 0.19032258064516128,
+      "acc_stderr": 0.022331707611823085,
+      "acc_norm": 0.25161290322580643,
+      "acc_norm_stderr": 0.024685979286239973
+    },
+    "hendrycksTest-business_ethics": {
+      "acc": 0.33,
+      "acc_stderr": 0.04725815626252604,
+      "acc_norm": 0.26,
+      "acc_norm_stderr": 0.04408440022768079
+    },
+    "hendrycksTest-medical_genetics": {
+      "acc": 0.31,
+      "acc_stderr": 0.04648231987117316,
+      "acc_norm": 0.36,
+      "acc_norm_stderr": 0.048241815132442176
+    },
+    "hendrycksTest-logical_fallacies": {
+      "acc": 0.1901840490797546,
+      "acc_stderr": 0.03083349114628124,
+      "acc_norm": 0.26993865030674846,
+      "acc_norm_stderr": 0.03487825168497892
+    },
+    "hendrycksTest-sociology": {
+      "acc": 0.2736318407960199,
+      "acc_stderr": 0.03152439186555404,
+      "acc_norm": 0.2885572139303483,
+      "acc_norm_stderr": 0.03203841040213322
+    },
+    "arc_easy": {
+      "acc": 0.5618686868686869,
+      "acc_stderr": 0.010180937100600085,
+      "acc_norm": 0.48063973063973064,
+      "acc_norm_stderr": 0.010252089491165513
+    },
+    "arc_challenge": {
+      "acc": 0.2380546075085324,
+      "acc_stderr": 0.012445770028026201,
+      "acc_norm": 0.2687713310580205,
+      "acc_norm_stderr": 0.01295506596371068
+    },
+    "hendrycksTest-elementary_mathematics": {
+      "acc": 0.1693121693121693,
+      "acc_stderr": 0.019314894311588695,
+      "acc_norm": 0.21693121693121692,
+      "acc_norm_stderr": 0.021227082449445045
+    }
+  },
+  "versions": {
+    "sciq": 0,
+    "hendrycksTest-nutrition": 0,
+    "logiqa": 0,
+    "hendrycksTest-moral_disputes": 0,
+    "hendrycksTest-jurisprudence": 0,
+    "hendrycksTest-public_relations": 0,
+    "hendrycksTest-high_school_computer_science": 0,
+    "hendrycksTest-college_medicine": 0,
+    "hendrycksTest-abstract_algebra": 0,
+    "hendrycksTest-human_sexuality": 0,
+    "hendrycksTest-professional_medicine": 0,
+    "hendrycksTest-econometrics": 0,
+    "hendrycksTest-miscellaneous": 0,
+    "hendrycksTest-college_biology": 0,
+    "hendrycksTest-college_computer_science": 0,
+    "hendrycksTest-global_facts": 0,
+    "hendrycksTest-international_law": 0,
+    "hendrycksTest-management": 0,
+    "hendrycksTest-marketing": 0,
+    "hendrycksTest-high_school_physics": 0,
+    "hendrycksTest-high_school_world_history": 0,
+    "hendrycksTest-high_school_psychology": 0,
+    "hendrycksTest-high_school_statistics": 0,
+    "hendrycksTest-world_religions": 0,
+    "hendrycksTest-high_school_geography": 0,
+    "hendrycksTest-human_aging": 0,
+    "hendrycksTest-machine_learning": 0,
+    "piqa": 0,
+    "hendrycksTest-high_school_chemistry": 0,
+    "hendrycksTest-professional_accounting": 0,
+    "hendrycksTest-college_physics": 0,
+    "hendrycksTest-college_chemistry": 0,
+    "hendrycksTest-conceptual_physics": 0,
+    "hendrycksTest-high_school_us_history": 0,
+    "winogrande": 0,
+    "hendrycksTest-professional_law": 0,
+    "hendrycksTest-moral_scenarios": 0,
+    "hendrycksTest-professional_psychology": 0,
+    "hendrycksTest-electrical_engineering": 0,
+    "hendrycksTest-security_studies": 0,
+    "hendrycksTest-high_school_microeconomics": 0,
+    "hendrycksTest-high_school_macroeconomics": 0,
+    "hendrycksTest-high_school_mathematics": 0,
+    "hendrycksTest-high_school_european_history": 0,
+    "hendrycksTest-prehistory": 0,
+    "hendrycksTest-astronomy": 0,
+    "lambada_openai": 0,
+    "hendrycksTest-high_school_government_and_politics": 0,
+    "wsc": 0,
+    "hendrycksTest-computer_security": 0,
+    "hendrycksTest-college_mathematics": 0,
+    "hendrycksTest-us_foreign_policy": 0,
+    "hendrycksTest-anatomy": 0,
+    "hendrycksTest-clinical_knowledge": 0,
+    "hendrycksTest-formal_logic": 0,
+    "hendrycksTest-virology": 0,
+    "hendrycksTest-philosophy": 0,
+    "hendrycksTest-high_school_biology": 0,
+    "hendrycksTest-business_ethics": 0,
+    "hendrycksTest-medical_genetics": 0,
+    "hendrycksTest-logical_fallacies": 0,
+    "hendrycksTest-sociology": 0,
+    "arc_easy": 0,
+    "arc_challenge": 0,
+    "hendrycksTest-elementary_mathematics": 0
+  },
+  "config": {
+    "model": "hf-causal",
+    "model_args": "pretrained=bigscience/bloom-1b7,use_accelerate=True,device_map_option=sequential,max_memory_per_gpu=40GIB",
+    "num_fewshot": 0,
+    "batch_size": 8,
+    "device": "cuda",
+    "no_cache": false,
+    "limit": null,
+    "bootstrap_iters": 100000,
+    "description_dict": {}
+  }
+}

--- a/results/bloom/bloom-3b.json
+++ b/results/bloom/bloom-3b.json
@@ -1,0 +1,468 @@
+{
+  "results": {
+    "hendrycksTest-anatomy": {
+      "acc": 0.25925925925925924,
+      "acc_stderr": 0.037857144650666544,
+      "acc_norm": 0.22962962962962963,
+      "acc_norm_stderr": 0.036333844140734615
+    },
+    "hendrycksTest-professional_law": {
+      "acc": 0.2457627118644068,
+      "acc_stderr": 0.01099615663514269,
+      "acc_norm": 0.2816166883963494,
+      "acc_norm_stderr": 0.011487783272786697
+    },
+    "arc_easy": {
+      "acc": 0.5938552188552189,
+      "acc_stderr": 0.010077409815364062,
+      "acc_norm": 0.5328282828282829,
+      "acc_norm_stderr": 0.010237645778853869
+    },
+    "hendrycksTest-high_school_european_history": {
+      "acc": 0.24242424242424243,
+      "acc_stderr": 0.033464098810559534,
+      "acc_norm": 0.2787878787878788,
+      "acc_norm_stderr": 0.03501438706296781
+    },
+    "hendrycksTest-econometrics": {
+      "acc": 0.3157894736842105,
+      "acc_stderr": 0.04372748290278007,
+      "acc_norm": 0.2719298245614035,
+      "acc_norm_stderr": 0.04185774424022056
+    },
+    "hendrycksTest-virology": {
+      "acc": 0.3373493975903614,
+      "acc_stderr": 0.03680783690727581,
+      "acc_norm": 0.28313253012048195,
+      "acc_norm_stderr": 0.03507295431370518
+    },
+    "hendrycksTest-high_school_us_history": {
+      "acc": 0.25,
+      "acc_stderr": 0.03039153369274154,
+      "acc_norm": 0.23039215686274508,
+      "acc_norm_stderr": 0.029554292605695063
+    },
+    "hendrycksTest-high_school_microeconomics": {
+      "acc": 0.2689075630252101,
+      "acc_stderr": 0.028801392193631276,
+      "acc_norm": 0.35714285714285715,
+      "acc_norm_stderr": 0.031124619309328177
+    },
+    "hendrycksTest-high_school_biology": {
+      "acc": 0.23870967741935484,
+      "acc_stderr": 0.024251071262208837,
+      "acc_norm": 0.2903225806451613,
+      "acc_norm_stderr": 0.0258221061194159
+    },
+    "hendrycksTest-prehistory": {
+      "acc": 0.26851851851851855,
+      "acc_stderr": 0.024659685185967284,
+      "acc_norm": 0.2191358024691358,
+      "acc_norm_stderr": 0.023016705640262192
+    },
+    "wsc": {
+      "acc": 0.375,
+      "acc_stderr": 0.04770204856076104
+    },
+    "hendrycksTest-business_ethics": {
+      "acc": 0.34,
+      "acc_stderr": 0.04760952285695236,
+      "acc_norm": 0.3,
+      "acc_norm_stderr": 0.046056618647183814
+    },
+    "hendrycksTest-electrical_engineering": {
+      "acc": 0.2827586206896552,
+      "acc_stderr": 0.037528339580033376,
+      "acc_norm": 0.30344827586206896,
+      "acc_norm_stderr": 0.038312260488503336
+    },
+    "arc_challenge": {
+      "acc": 0.27986348122866894,
+      "acc_stderr": 0.013119040897725922,
+      "acc_norm": 0.3037542662116041,
+      "acc_norm_stderr": 0.013438909184778759
+    },
+    "hendrycksTest-high_school_world_history": {
+      "acc": 0.25738396624472576,
+      "acc_stderr": 0.0284588209914603,
+      "acc_norm": 0.27848101265822783,
+      "acc_norm_stderr": 0.02917868230484255
+    },
+    "hendrycksTest-high_school_computer_science": {
+      "acc": 0.23,
+      "acc_stderr": 0.04229525846816505,
+      "acc_norm": 0.29,
+      "acc_norm_stderr": 0.045604802157206845
+    },
+    "hendrycksTest-college_physics": {
+      "acc": 0.23529411764705882,
+      "acc_stderr": 0.04220773659171452,
+      "acc_norm": 0.2549019607843137,
+      "acc_norm_stderr": 0.043364327079931785
+    },
+    "hendrycksTest-professional_medicine": {
+      "acc": 0.2426470588235294,
+      "acc_stderr": 0.026040662474201257,
+      "acc_norm": 0.2610294117647059,
+      "acc_norm_stderr": 0.026679252270103128
+    },
+    "piqa": {
+      "acc": 0.7078346028291621,
+      "acc_stderr": 0.010610252174513661,
+      "acc_norm": 0.7067464635473341,
+      "acc_norm_stderr": 0.010621818421101931
+    },
+    "hendrycksTest-college_mathematics": {
+      "acc": 0.26,
+      "acc_stderr": 0.0440844002276808,
+      "acc_norm": 0.39,
+      "acc_norm_stderr": 0.04902071300001975
+    },
+    "logiqa": {
+      "acc": 0.20583717357910905,
+      "acc_stderr": 0.015858423219323892,
+      "acc_norm": 0.29185867895545314,
+      "acc_norm_stderr": 0.017831570553971925
+    },
+    "hendrycksTest-high_school_macroeconomics": {
+      "acc": 0.2692307692307692,
+      "acc_stderr": 0.022489389793654824,
+      "acc_norm": 0.25384615384615383,
+      "acc_norm_stderr": 0.022066054378726257
+    },
+    "hendrycksTest-management": {
+      "acc": 0.1650485436893204,
+      "acc_stderr": 0.03675668832233188,
+      "acc_norm": 0.2524271844660194,
+      "acc_norm_stderr": 0.04301250399690877
+    },
+    "hendrycksTest-jurisprudence": {
+      "acc": 0.25925925925925924,
+      "acc_stderr": 0.04236511258094632,
+      "acc_norm": 0.4166666666666667,
+      "acc_norm_stderr": 0.04766075165356461
+    },
+    "hendrycksTest-marketing": {
+      "acc": 0.33760683760683763,
+      "acc_stderr": 0.03098029699261856,
+      "acc_norm": 0.3504273504273504,
+      "acc_norm_stderr": 0.031256108244218817
+    },
+    "hendrycksTest-moral_scenarios": {
+      "acc": 0.23687150837988827,
+      "acc_stderr": 0.01421957078810399,
+      "acc_norm": 0.27262569832402234,
+      "acc_norm_stderr": 0.014893391735249588
+    },
+    "hendrycksTest-elementary_mathematics": {
+      "acc": 0.23544973544973544,
+      "acc_stderr": 0.021851509822031732,
+      "acc_norm": 0.22486772486772486,
+      "acc_norm_stderr": 0.021502096078229147
+    },
+    "hendrycksTest-conceptual_physics": {
+      "acc": 0.225531914893617,
+      "acc_stderr": 0.027321078417387536,
+      "acc_norm": 0.20425531914893616,
+      "acc_norm_stderr": 0.026355158413349417
+    },
+    "hendrycksTest-college_computer_science": {
+      "acc": 0.22,
+      "acc_stderr": 0.041633319989322695,
+      "acc_norm": 0.24,
+      "acc_norm_stderr": 0.04292346959909282
+    },
+    "hendrycksTest-abstract_algebra": {
+      "acc": 0.21,
+      "acc_stderr": 0.040936018074033256,
+      "acc_norm": 0.27,
+      "acc_norm_stderr": 0.0446196043338474
+    },
+    "hendrycksTest-nutrition": {
+      "acc": 0.3137254901960784,
+      "acc_stderr": 0.02656892101545716,
+      "acc_norm": 0.37254901960784315,
+      "acc_norm_stderr": 0.027684181883302884
+    },
+    "hendrycksTest-human_sexuality": {
+      "acc": 0.33587786259541985,
+      "acc_stderr": 0.041423137719966634,
+      "acc_norm": 0.2748091603053435,
+      "acc_norm_stderr": 0.03915345408847836
+    },
+    "hendrycksTest-miscellaneous": {
+      "acc": 0.29757343550446996,
+      "acc_stderr": 0.01634911191290943,
+      "acc_norm": 0.2681992337164751,
+      "acc_norm_stderr": 0.015842430835269445
+    },
+    "hendrycksTest-security_studies": {
+      "acc": 0.27755102040816326,
+      "acc_stderr": 0.028666857790274655,
+      "acc_norm": 0.2571428571428571,
+      "acc_norm_stderr": 0.02797982353874455
+    },
+    "hendrycksTest-college_chemistry": {
+      "acc": 0.23,
+      "acc_stderr": 0.042295258468165065,
+      "acc_norm": 0.3,
+      "acc_norm_stderr": 0.046056618647183814
+    },
+    "hendrycksTest-high_school_government_and_politics": {
+      "acc": 0.22797927461139897,
+      "acc_stderr": 0.03027690994517826,
+      "acc_norm": 0.25906735751295334,
+      "acc_norm_stderr": 0.031618779179354094
+    },
+    "hendrycksTest-astronomy": {
+      "acc": 0.2894736842105263,
+      "acc_stderr": 0.03690677986137283,
+      "acc_norm": 0.34210526315789475,
+      "acc_norm_stderr": 0.038607315993160925
+    },
+    "hendrycksTest-high_school_psychology": {
+      "acc": 0.22935779816513763,
+      "acc_stderr": 0.018025349724618684,
+      "acc_norm": 0.23302752293577983,
+      "acc_norm_stderr": 0.018125669180861496
+    },
+    "hendrycksTest-computer_security": {
+      "acc": 0.26,
+      "acc_stderr": 0.04408440022768079,
+      "acc_norm": 0.34,
+      "acc_norm_stderr": 0.04760952285695236
+    },
+    "hendrycksTest-machine_learning": {
+      "acc": 0.2767857142857143,
+      "acc_stderr": 0.042466243366976256,
+      "acc_norm": 0.22321428571428573,
+      "acc_norm_stderr": 0.039523019677025116
+    },
+    "hendrycksTest-international_law": {
+      "acc": 0.23140495867768596,
+      "acc_stderr": 0.03849856098794088,
+      "acc_norm": 0.4214876033057851,
+      "acc_norm_stderr": 0.045077322787750944
+    },
+    "hendrycksTest-medical_genetics": {
+      "acc": 0.24,
+      "acc_stderr": 0.04292346959909283,
+      "acc_norm": 0.33,
+      "acc_norm_stderr": 0.04725815626252604
+    },
+    "hendrycksTest-us_foreign_policy": {
+      "acc": 0.31,
+      "acc_stderr": 0.04648231987117316,
+      "acc_norm": 0.29,
+      "acc_norm_stderr": 0.04560480215720683
+    },
+    "hendrycksTest-public_relations": {
+      "acc": 0.3,
+      "acc_stderr": 0.04389311454644286,
+      "acc_norm": 0.17272727272727273,
+      "acc_norm_stderr": 0.03620691833929218
+    },
+    "lambada_openai": {
+      "ppl": 9.094806761207808,
+      "ppl_stderr": 0.2652044586962106,
+      "acc": 0.5179507083252475,
+      "acc_stderr": 0.006961486944579348
+    },
+    "hendrycksTest-college_medicine": {
+      "acc": 0.20809248554913296,
+      "acc_stderr": 0.030952890217749884,
+      "acc_norm": 0.23699421965317918,
+      "acc_norm_stderr": 0.03242414757483098
+    },
+    "hendrycksTest-world_religions": {
+      "acc": 0.2573099415204678,
+      "acc_stderr": 0.03352799844161865,
+      "acc_norm": 0.38596491228070173,
+      "acc_norm_stderr": 0.03733756969066164
+    },
+    "hendrycksTest-professional_psychology": {
+      "acc": 0.25980392156862747,
+      "acc_stderr": 0.017740899509177788,
+      "acc_norm": 0.28104575163398693,
+      "acc_norm_stderr": 0.018185218954318086
+    },
+    "hendrycksTest-college_biology": {
+      "acc": 0.2569444444444444,
+      "acc_stderr": 0.03653946969442099,
+      "acc_norm": 0.2152777777777778,
+      "acc_norm_stderr": 0.03437079344106135
+    },
+    "hendrycksTest-global_facts": {
+      "acc": 0.28,
+      "acc_stderr": 0.04512608598542128,
+      "acc_norm": 0.25,
+      "acc_norm_stderr": 0.04351941398892446
+    },
+    "winogrande": {
+      "acc": 0.5864246250986582,
+      "acc_stderr": 0.013840971763195303
+    },
+    "hendrycksTest-logical_fallacies": {
+      "acc": 0.22085889570552147,
+      "acc_stderr": 0.03259177392742178,
+      "acc_norm": 0.3128834355828221,
+      "acc_norm_stderr": 0.03642914578292405
+    },
+    "hendrycksTest-sociology": {
+      "acc": 0.263681592039801,
+      "acc_stderr": 0.03115715086935556,
+      "acc_norm": 0.23880597014925373,
+      "acc_norm_stderr": 0.030147775935409217
+    },
+    "hendrycksTest-moral_disputes": {
+      "acc": 0.2947976878612717,
+      "acc_stderr": 0.024547617794803835,
+      "acc_norm": 0.33815028901734107,
+      "acc_norm_stderr": 0.02546977014940017
+    },
+    "hendrycksTest-high_school_mathematics": {
+      "acc": 0.2222222222222222,
+      "acc_stderr": 0.02534809746809784,
+      "acc_norm": 0.26296296296296295,
+      "acc_norm_stderr": 0.02684205787383371
+    },
+    "hendrycksTest-high_school_chemistry": {
+      "acc": 0.22167487684729065,
+      "acc_stderr": 0.029225575892489614,
+      "acc_norm": 0.2955665024630542,
+      "acc_norm_stderr": 0.032104944337514575
+    },
+    "hendrycksTest-professional_accounting": {
+      "acc": 0.24468085106382978,
+      "acc_stderr": 0.025645553622266736,
+      "acc_norm": 0.2801418439716312,
+      "acc_norm_stderr": 0.026789172351140242
+    },
+    "sciq": {
+      "acc": 0.891,
+      "acc_stderr": 0.009859828407037191,
+      "acc_norm": 0.817,
+      "acc_norm_stderr": 0.012233587399477823
+    },
+    "hendrycksTest-clinical_knowledge": {
+      "acc": 0.2490566037735849,
+      "acc_stderr": 0.026616482980501708,
+      "acc_norm": 0.3283018867924528,
+      "acc_norm_stderr": 0.02890159361241178
+    },
+    "hendrycksTest-human_aging": {
+      "acc": 0.2825112107623318,
+      "acc_stderr": 0.030216831011508766,
+      "acc_norm": 0.2645739910313901,
+      "acc_norm_stderr": 0.029605103217038308
+    },
+    "hendrycksTest-formal_logic": {
+      "acc": 0.31746031746031744,
+      "acc_stderr": 0.041634530313028585,
+      "acc_norm": 0.31746031746031744,
+      "acc_norm_stderr": 0.04163453031302859
+    },
+    "hendrycksTest-philosophy": {
+      "acc": 0.2572347266881029,
+      "acc_stderr": 0.024826171289250888,
+      "acc_norm": 0.2958199356913183,
+      "acc_norm_stderr": 0.025922371788818788
+    },
+    "hendrycksTest-high_school_geography": {
+      "acc": 0.21212121212121213,
+      "acc_stderr": 0.029126522834586815,
+      "acc_norm": 0.2878787878787879,
+      "acc_norm_stderr": 0.03225883512300992
+    },
+    "hendrycksTest-high_school_physics": {
+      "acc": 0.2052980132450331,
+      "acc_stderr": 0.032979866484738364,
+      "acc_norm": 0.23841059602649006,
+      "acc_norm_stderr": 0.03479185572599659
+    },
+    "hendrycksTest-high_school_statistics": {
+      "acc": 0.24537037037037038,
+      "acc_stderr": 0.029346665094372944,
+      "acc_norm": 0.3101851851851852,
+      "acc_norm_stderr": 0.031546962856566295
+    }
+  },
+  "versions": {
+    "hendrycksTest-anatomy": 0,
+    "hendrycksTest-professional_law": 0,
+    "arc_easy": 0,
+    "hendrycksTest-high_school_european_history": 0,
+    "hendrycksTest-econometrics": 0,
+    "hendrycksTest-virology": 0,
+    "hendrycksTest-high_school_us_history": 0,
+    "hendrycksTest-high_school_microeconomics": 0,
+    "hendrycksTest-high_school_biology": 0,
+    "hendrycksTest-prehistory": 0,
+    "wsc": 0,
+    "hendrycksTest-business_ethics": 0,
+    "hendrycksTest-electrical_engineering": 0,
+    "arc_challenge": 0,
+    "hendrycksTest-high_school_world_history": 0,
+    "hendrycksTest-high_school_computer_science": 0,
+    "hendrycksTest-college_physics": 0,
+    "hendrycksTest-professional_medicine": 0,
+    "piqa": 0,
+    "hendrycksTest-college_mathematics": 0,
+    "logiqa": 0,
+    "hendrycksTest-high_school_macroeconomics": 0,
+    "hendrycksTest-management": 0,
+    "hendrycksTest-jurisprudence": 0,
+    "hendrycksTest-marketing": 0,
+    "hendrycksTest-moral_scenarios": 0,
+    "hendrycksTest-elementary_mathematics": 0,
+    "hendrycksTest-conceptual_physics": 0,
+    "hendrycksTest-college_computer_science": 0,
+    "hendrycksTest-abstract_algebra": 0,
+    "hendrycksTest-nutrition": 0,
+    "hendrycksTest-human_sexuality": 0,
+    "hendrycksTest-miscellaneous": 0,
+    "hendrycksTest-security_studies": 0,
+    "hendrycksTest-college_chemistry": 0,
+    "hendrycksTest-high_school_government_and_politics": 0,
+    "hendrycksTest-astronomy": 0,
+    "hendrycksTest-high_school_psychology": 0,
+    "hendrycksTest-computer_security": 0,
+    "hendrycksTest-machine_learning": 0,
+    "hendrycksTest-international_law": 0,
+    "hendrycksTest-medical_genetics": 0,
+    "hendrycksTest-us_foreign_policy": 0,
+    "hendrycksTest-public_relations": 0,
+    "lambada_openai": 0,
+    "hendrycksTest-college_medicine": 0,
+    "hendrycksTest-world_religions": 0,
+    "hendrycksTest-professional_psychology": 0,
+    "hendrycksTest-college_biology": 0,
+    "hendrycksTest-global_facts": 0,
+    "winogrande": 0,
+    "hendrycksTest-logical_fallacies": 0,
+    "hendrycksTest-sociology": 0,
+    "hendrycksTest-moral_disputes": 0,
+    "hendrycksTest-high_school_mathematics": 0,
+    "hendrycksTest-high_school_chemistry": 0,
+    "hendrycksTest-professional_accounting": 0,
+    "sciq": 0,
+    "hendrycksTest-clinical_knowledge": 0,
+    "hendrycksTest-human_aging": 0,
+    "hendrycksTest-formal_logic": 0,
+    "hendrycksTest-philosophy": 0,
+    "hendrycksTest-high_school_geography": 0,
+    "hendrycksTest-high_school_physics": 0,
+    "hendrycksTest-high_school_statistics": 0
+  },
+  "config": {
+    "model": "hf-causal",
+    "model_args": "pretrained=bigscience/bloom-3b,use_accelerate=True,device_map_option=sequential,max_memory_per_gpu=40GIB",
+    "num_fewshot": 0,
+    "batch_size": 8,
+    "device": "cuda",
+    "no_cache": false,
+    "limit": null,
+    "bootstrap_iters": 100000,
+    "description_dict": {}
+  }
+}

--- a/results/bloom/bloom-560m.json
+++ b/results/bloom/bloom-560m.json
@@ -1,0 +1,468 @@
+{
+  "results": {
+    "hendrycksTest-marketing": {
+      "acc": 0.3034188034188034,
+      "acc_stderr": 0.030118210106942666,
+      "acc_norm": 0.3247863247863248,
+      "acc_norm_stderr": 0.030679022765498835
+    },
+    "arc_challenge": {
+      "acc": 0.22098976109215018,
+      "acc_stderr": 0.012124929206818258,
+      "acc_norm": 0.24061433447098976,
+      "acc_norm_stderr": 0.012491468532390575
+    },
+    "hendrycksTest-college_computer_science": {
+      "acc": 0.24,
+      "acc_stderr": 0.04292346959909282,
+      "acc_norm": 0.27,
+      "acc_norm_stderr": 0.04461960433384741
+    },
+    "hendrycksTest-high_school_european_history": {
+      "acc": 0.24242424242424243,
+      "acc_stderr": 0.03346409881055953,
+      "acc_norm": 0.2727272727272727,
+      "acc_norm_stderr": 0.0347769116216366
+    },
+    "hendrycksTest-business_ethics": {
+      "acc": 0.34,
+      "acc_stderr": 0.04760952285695235,
+      "acc_norm": 0.27,
+      "acc_norm_stderr": 0.044619604333847394
+    },
+    "hendrycksTest-high_school_mathematics": {
+      "acc": 0.22592592592592592,
+      "acc_stderr": 0.025497532639609553,
+      "acc_norm": 0.2777777777777778,
+      "acc_norm_stderr": 0.027309140588230175
+    },
+    "hendrycksTest-miscellaneous": {
+      "acc": 0.24776500638569604,
+      "acc_stderr": 0.01543808308056895,
+      "acc_norm": 0.23627075351213284,
+      "acc_norm_stderr": 0.015190473717037491
+    },
+    "hendrycksTest-professional_accounting": {
+      "acc": 0.25177304964539005,
+      "acc_stderr": 0.0258921511567094,
+      "acc_norm": 0.26595744680851063,
+      "acc_norm_stderr": 0.02635806569888059
+    },
+    "hendrycksTest-college_physics": {
+      "acc": 0.20588235294117646,
+      "acc_stderr": 0.04023382273617747,
+      "acc_norm": 0.2647058823529412,
+      "acc_norm_stderr": 0.043898699568087785
+    },
+    "hendrycksTest-high_school_chemistry": {
+      "acc": 0.2315270935960591,
+      "acc_stderr": 0.029678333141444455,
+      "acc_norm": 0.27586206896551724,
+      "acc_norm_stderr": 0.031447125816782426
+    },
+    "hendrycksTest-international_law": {
+      "acc": 0.19834710743801653,
+      "acc_stderr": 0.036401182719909456,
+      "acc_norm": 0.4297520661157025,
+      "acc_norm_stderr": 0.04519082021319772
+    },
+    "hendrycksTest-public_relations": {
+      "acc": 0.2636363636363636,
+      "acc_stderr": 0.04220224692971987,
+      "acc_norm": 0.18181818181818182,
+      "acc_norm_stderr": 0.03694284335337799
+    },
+    "hendrycksTest-prehistory": {
+      "acc": 0.20987654320987653,
+      "acc_stderr": 0.02265834408598136,
+      "acc_norm": 0.20987654320987653,
+      "acc_norm_stderr": 0.02265834408598135
+    },
+    "hendrycksTest-world_religions": {
+      "acc": 0.25146198830409355,
+      "acc_stderr": 0.033275044238468436,
+      "acc_norm": 0.3391812865497076,
+      "acc_norm_stderr": 0.03631053496488905
+    },
+    "hendrycksTest-medical_genetics": {
+      "acc": 0.24,
+      "acc_stderr": 0.04292346959909284,
+      "acc_norm": 0.31,
+      "acc_norm_stderr": 0.04648231987117316
+    },
+    "hendrycksTest-high_school_computer_science": {
+      "acc": 0.21,
+      "acc_stderr": 0.040936018074033256,
+      "acc_norm": 0.23,
+      "acc_norm_stderr": 0.04229525846816505
+    },
+    "piqa": {
+      "acc": 0.6365614798694232,
+      "acc_stderr": 0.011222279395304511,
+      "acc_norm": 0.6485310119695321,
+      "acc_norm_stderr": 0.011139207691931193
+    },
+    "hendrycksTest-college_medicine": {
+      "acc": 0.1907514450867052,
+      "acc_stderr": 0.029957851329869337,
+      "acc_norm": 0.2658959537572254,
+      "acc_norm_stderr": 0.0336876293225943
+    },
+    "hendrycksTest-high_school_us_history": {
+      "acc": 0.25980392156862747,
+      "acc_stderr": 0.030778554678693264,
+      "acc_norm": 0.2647058823529412,
+      "acc_norm_stderr": 0.03096451792692341
+    },
+    "hendrycksTest-human_sexuality": {
+      "acc": 0.29770992366412213,
+      "acc_stderr": 0.040103589424622034,
+      "acc_norm": 0.29770992366412213,
+      "acc_norm_stderr": 0.040103589424622034
+    },
+    "wsc": {
+      "acc": 0.4423076923076923,
+      "acc_stderr": 0.04893740777701
+    },
+    "hendrycksTest-college_chemistry": {
+      "acc": 0.23,
+      "acc_stderr": 0.04229525846816508,
+      "acc_norm": 0.3,
+      "acc_norm_stderr": 0.046056618647183814
+    },
+    "hendrycksTest-college_mathematics": {
+      "acc": 0.25,
+      "acc_stderr": 0.04351941398892446,
+      "acc_norm": 0.28,
+      "acc_norm_stderr": 0.04512608598542127
+    },
+    "hendrycksTest-us_foreign_policy": {
+      "acc": 0.29,
+      "acc_stderr": 0.045604802157206845,
+      "acc_norm": 0.29,
+      "acc_norm_stderr": 0.04560480215720684
+    },
+    "hendrycksTest-high_school_macroeconomics": {
+      "acc": 0.22564102564102564,
+      "acc_stderr": 0.02119363252514853,
+      "acc_norm": 0.25384615384615383,
+      "acc_norm_stderr": 0.022066054378726257
+    },
+    "hendrycksTest-sociology": {
+      "acc": 0.263681592039801,
+      "acc_stderr": 0.03115715086935556,
+      "acc_norm": 0.263681592039801,
+      "acc_norm_stderr": 0.03115715086935555
+    },
+    "sciq": {
+      "acc": 0.804,
+      "acc_stderr": 0.012559527926707389,
+      "acc_norm": 0.711,
+      "acc_norm_stderr": 0.014341711358296176
+    },
+    "hendrycksTest-anatomy": {
+      "acc": 0.2074074074074074,
+      "acc_stderr": 0.03502553170678318,
+      "acc_norm": 0.2074074074074074,
+      "acc_norm_stderr": 0.03502553170678315
+    },
+    "arc_easy": {
+      "acc": 0.47558922558922556,
+      "acc_stderr": 0.010247548905242272,
+      "acc_norm": 0.4196127946127946,
+      "acc_norm_stderr": 0.010126315840891532
+    },
+    "hendrycksTest-high_school_microeconomics": {
+      "acc": 0.23529411764705882,
+      "acc_stderr": 0.027553614467863814,
+      "acc_norm": 0.3319327731092437,
+      "acc_norm_stderr": 0.030588697013783663
+    },
+    "hendrycksTest-jurisprudence": {
+      "acc": 0.25925925925925924,
+      "acc_stderr": 0.04236511258094633,
+      "acc_norm": 0.4074074074074074,
+      "acc_norm_stderr": 0.04750077341199986
+    },
+    "hendrycksTest-logical_fallacies": {
+      "acc": 0.24539877300613497,
+      "acc_stderr": 0.03380939813943354,
+      "acc_norm": 0.3374233128834356,
+      "acc_norm_stderr": 0.03714908409935574
+    },
+    "hendrycksTest-moral_disputes": {
+      "acc": 0.2254335260115607,
+      "acc_stderr": 0.022497230190967554,
+      "acc_norm": 0.30346820809248554,
+      "acc_norm_stderr": 0.02475241196091721
+    },
+    "hendrycksTest-security_studies": {
+      "acc": 0.2897959183673469,
+      "acc_stderr": 0.02904308868330434,
+      "acc_norm": 0.2653061224489796,
+      "acc_norm_stderr": 0.028263889943784606
+    },
+    "hendrycksTest-conceptual_physics": {
+      "acc": 0.25957446808510637,
+      "acc_stderr": 0.02865917937429232,
+      "acc_norm": 0.19574468085106383,
+      "acc_norm_stderr": 0.025937853139977148
+    },
+    "hendrycksTest-human_aging": {
+      "acc": 0.3273542600896861,
+      "acc_stderr": 0.03149384670994131,
+      "acc_norm": 0.273542600896861,
+      "acc_norm_stderr": 0.029918586707798817
+    },
+    "hendrycksTest-global_facts": {
+      "acc": 0.16,
+      "acc_stderr": 0.03684529491774709,
+      "acc_norm": 0.22,
+      "acc_norm_stderr": 0.041633319989322695
+    },
+    "hendrycksTest-elementary_mathematics": {
+      "acc": 0.21428571428571427,
+      "acc_stderr": 0.021132859182754444,
+      "acc_norm": 0.21957671957671956,
+      "acc_norm_stderr": 0.021320018599770348
+    },
+    "hendrycksTest-high_school_physics": {
+      "acc": 0.18543046357615894,
+      "acc_stderr": 0.03173284384294285,
+      "acc_norm": 0.2119205298013245,
+      "acc_norm_stderr": 0.03336767086567977
+    },
+    "hendrycksTest-high_school_government_and_politics": {
+      "acc": 0.17616580310880828,
+      "acc_stderr": 0.02749350424454805,
+      "acc_norm": 0.23834196891191708,
+      "acc_norm_stderr": 0.030748905363909895
+    },
+    "hendrycksTest-moral_scenarios": {
+      "acc": 0.23910614525139665,
+      "acc_stderr": 0.014265554192331144,
+      "acc_norm": 0.2770949720670391,
+      "acc_norm_stderr": 0.01496877243581215
+    },
+    "lambada_openai": {
+      "ppl": 28.771677896772093,
+      "ppl_stderr": 1.0881220668030018,
+      "acc": 0.340966427323889,
+      "acc_stderr": 0.00660422182226587
+    },
+    "hendrycksTest-astronomy": {
+      "acc": 0.20394736842105263,
+      "acc_stderr": 0.032790004063100515,
+      "acc_norm": 0.3157894736842105,
+      "acc_norm_stderr": 0.0378272898086547
+    },
+    "hendrycksTest-professional_medicine": {
+      "acc": 0.1948529411764706,
+      "acc_stderr": 0.024060599423487428,
+      "acc_norm": 0.23529411764705882,
+      "acc_norm_stderr": 0.025767252010855952
+    },
+    "hendrycksTest-virology": {
+      "acc": 0.2891566265060241,
+      "acc_stderr": 0.03529486801511115,
+      "acc_norm": 0.25301204819277107,
+      "acc_norm_stderr": 0.03384429155233137
+    },
+    "hendrycksTest-electrical_engineering": {
+      "acc": 0.3310344827586207,
+      "acc_stderr": 0.039215453124671215,
+      "acc_norm": 0.3103448275862069,
+      "acc_norm_stderr": 0.038552896163789485
+    },
+    "hendrycksTest-high_school_psychology": {
+      "acc": 0.2036697247706422,
+      "acc_stderr": 0.0172667420876308,
+      "acc_norm": 0.2,
+      "acc_norm_stderr": 0.017149858514250944
+    },
+    "hendrycksTest-econometrics": {
+      "acc": 0.2543859649122807,
+      "acc_stderr": 0.040969851398436716,
+      "acc_norm": 0.23684210526315788,
+      "acc_norm_stderr": 0.03999423879281336
+    },
+    "hendrycksTest-high_school_statistics": {
+      "acc": 0.2037037037037037,
+      "acc_stderr": 0.027467401804057982,
+      "acc_norm": 0.24074074074074073,
+      "acc_norm_stderr": 0.029157522184605603
+    },
+    "hendrycksTest-management": {
+      "acc": 0.1553398058252427,
+      "acc_stderr": 0.035865947385739755,
+      "acc_norm": 0.21359223300970873,
+      "acc_norm_stderr": 0.04058042015646036
+    },
+    "logiqa": {
+      "acc": 0.21658986175115208,
+      "acc_stderr": 0.016156860583178303,
+      "acc_norm": 0.26881720430107525,
+      "acc_norm_stderr": 0.017389409463712625
+    },
+    "hendrycksTest-machine_learning": {
+      "acc": 0.32142857142857145,
+      "acc_stderr": 0.0443280405529152,
+      "acc_norm": 0.25892857142857145,
+      "acc_norm_stderr": 0.04157751539865629
+    },
+    "hendrycksTest-philosophy": {
+      "acc": 0.2057877813504823,
+      "acc_stderr": 0.022961339906764248,
+      "acc_norm": 0.28938906752411575,
+      "acc_norm_stderr": 0.025755865922632928
+    },
+    "hendrycksTest-formal_logic": {
+      "acc": 0.30158730158730157,
+      "acc_stderr": 0.04104947269903394,
+      "acc_norm": 0.29365079365079366,
+      "acc_norm_stderr": 0.040735243221471255
+    },
+    "hendrycksTest-nutrition": {
+      "acc": 0.25163398692810457,
+      "acc_stderr": 0.024848018263875195,
+      "acc_norm": 0.369281045751634,
+      "acc_norm_stderr": 0.02763417668960266
+    },
+    "hendrycksTest-computer_security": {
+      "acc": 0.3,
+      "acc_stderr": 0.046056618647183814,
+      "acc_norm": 0.28,
+      "acc_norm_stderr": 0.04512608598542128
+    },
+    "hendrycksTest-college_biology": {
+      "acc": 0.2222222222222222,
+      "acc_stderr": 0.03476590104304134,
+      "acc_norm": 0.1736111111111111,
+      "acc_norm_stderr": 0.031674733837957166
+    },
+    "hendrycksTest-high_school_biology": {
+      "acc": 0.2,
+      "acc_stderr": 0.022755204959542936,
+      "acc_norm": 0.24193548387096775,
+      "acc_norm_stderr": 0.024362599693031086
+    },
+    "winogrande": {
+      "acc": 0.5043409629044988,
+      "acc_stderr": 0.0140519560640769
+    },
+    "hendrycksTest-professional_law": {
+      "acc": 0.2561929595827901,
+      "acc_stderr": 0.011149173153110578,
+      "acc_norm": 0.2790091264667536,
+      "acc_norm_stderr": 0.011455208832803545
+    },
+    "hendrycksTest-professional_psychology": {
+      "acc": 0.2549019607843137,
+      "acc_stderr": 0.017630827375148383,
+      "acc_norm": 0.28104575163398693,
+      "acc_norm_stderr": 0.018185218954318082
+    },
+    "hendrycksTest-abstract_algebra": {
+      "acc": 0.19,
+      "acc_stderr": 0.039427724440366234,
+      "acc_norm": 0.27,
+      "acc_norm_stderr": 0.0446196043338474
+    },
+    "hendrycksTest-clinical_knowledge": {
+      "acc": 0.24528301886792453,
+      "acc_stderr": 0.02648035717989569,
+      "acc_norm": 0.3132075471698113,
+      "acc_norm_stderr": 0.028544793319055326
+    },
+    "hendrycksTest-high_school_world_history": {
+      "acc": 0.3080168776371308,
+      "acc_stderr": 0.0300523893356057,
+      "acc_norm": 0.2911392405063291,
+      "acc_norm_stderr": 0.029571601065753374
+    },
+    "hendrycksTest-high_school_geography": {
+      "acc": 0.20202020202020202,
+      "acc_stderr": 0.02860620428922988,
+      "acc_norm": 0.2777777777777778,
+      "acc_norm_stderr": 0.03191178226713548
+    }
+  },
+  "versions": {
+    "hendrycksTest-marketing": 0,
+    "arc_challenge": 0,
+    "hendrycksTest-college_computer_science": 0,
+    "hendrycksTest-high_school_european_history": 0,
+    "hendrycksTest-business_ethics": 0,
+    "hendrycksTest-high_school_mathematics": 0,
+    "hendrycksTest-miscellaneous": 0,
+    "hendrycksTest-professional_accounting": 0,
+    "hendrycksTest-college_physics": 0,
+    "hendrycksTest-high_school_chemistry": 0,
+    "hendrycksTest-international_law": 0,
+    "hendrycksTest-public_relations": 0,
+    "hendrycksTest-prehistory": 0,
+    "hendrycksTest-world_religions": 0,
+    "hendrycksTest-medical_genetics": 0,
+    "hendrycksTest-high_school_computer_science": 0,
+    "piqa": 0,
+    "hendrycksTest-college_medicine": 0,
+    "hendrycksTest-high_school_us_history": 0,
+    "hendrycksTest-human_sexuality": 0,
+    "wsc": 0,
+    "hendrycksTest-college_chemistry": 0,
+    "hendrycksTest-college_mathematics": 0,
+    "hendrycksTest-us_foreign_policy": 0,
+    "hendrycksTest-high_school_macroeconomics": 0,
+    "hendrycksTest-sociology": 0,
+    "sciq": 0,
+    "hendrycksTest-anatomy": 0,
+    "arc_easy": 0,
+    "hendrycksTest-high_school_microeconomics": 0,
+    "hendrycksTest-jurisprudence": 0,
+    "hendrycksTest-logical_fallacies": 0,
+    "hendrycksTest-moral_disputes": 0,
+    "hendrycksTest-security_studies": 0,
+    "hendrycksTest-conceptual_physics": 0,
+    "hendrycksTest-human_aging": 0,
+    "hendrycksTest-global_facts": 0,
+    "hendrycksTest-elementary_mathematics": 0,
+    "hendrycksTest-high_school_physics": 0,
+    "hendrycksTest-high_school_government_and_politics": 0,
+    "hendrycksTest-moral_scenarios": 0,
+    "lambada_openai": 0,
+    "hendrycksTest-astronomy": 0,
+    "hendrycksTest-professional_medicine": 0,
+    "hendrycksTest-virology": 0,
+    "hendrycksTest-electrical_engineering": 0,
+    "hendrycksTest-high_school_psychology": 0,
+    "hendrycksTest-econometrics": 0,
+    "hendrycksTest-high_school_statistics": 0,
+    "hendrycksTest-management": 0,
+    "logiqa": 0,
+    "hendrycksTest-machine_learning": 0,
+    "hendrycksTest-philosophy": 0,
+    "hendrycksTest-formal_logic": 0,
+    "hendrycksTest-nutrition": 0,
+    "hendrycksTest-computer_security": 0,
+    "hendrycksTest-college_biology": 0,
+    "hendrycksTest-high_school_biology": 0,
+    "winogrande": 0,
+    "hendrycksTest-professional_law": 0,
+    "hendrycksTest-professional_psychology": 0,
+    "hendrycksTest-abstract_algebra": 0,
+    "hendrycksTest-clinical_knowledge": 0,
+    "hendrycksTest-high_school_world_history": 0,
+    "hendrycksTest-high_school_geography": 0
+  },
+  "config": {
+    "model": "hf-causal",
+    "model_args": "pretrained=bigscience/bloom-560m,use_accelerate=True,device_map_option=sequential,max_memory_per_gpu=40GIB",
+    "num_fewshot": 0,
+    "batch_size": 1,
+    "device": "cuda",
+    "no_cache": false,
+    "limit": null,
+    "bootstrap_iters": 100000,
+    "description_dict": {}
+  }
+}

--- a/results/bloom/bloom-7b1.json
+++ b/results/bloom/bloom-7b1.json
@@ -1,0 +1,468 @@
+{
+  "results": {
+    "hendrycksTest-professional_medicine": {
+      "acc": 0.2647058823529412,
+      "acc_stderr": 0.026799562024887664,
+      "acc_norm": 0.2610294117647059,
+      "acc_norm_stderr": 0.026679252270103128
+    },
+    "hendrycksTest-high_school_world_history": {
+      "acc": 0.2869198312236287,
+      "acc_stderr": 0.029443773022594696,
+      "acc_norm": 0.2911392405063291,
+      "acc_norm_stderr": 0.02957160106575337
+    },
+    "hendrycksTest-elementary_mathematics": {
+      "acc": 0.30687830687830686,
+      "acc_stderr": 0.023752928712112126,
+      "acc_norm": 0.29894179894179895,
+      "acc_norm_stderr": 0.023577604791655802
+    },
+    "hendrycksTest-clinical_knowledge": {
+      "acc": 0.2943396226415094,
+      "acc_stderr": 0.028049186315695248,
+      "acc_norm": 0.3584905660377358,
+      "acc_norm_stderr": 0.029514703583981762
+    },
+    "hendrycksTest-global_facts": {
+      "acc": 0.27,
+      "acc_stderr": 0.044619604333847394,
+      "acc_norm": 0.25,
+      "acc_norm_stderr": 0.04351941398892446
+    },
+    "hendrycksTest-prehistory": {
+      "acc": 0.24382716049382716,
+      "acc_stderr": 0.023891879541959603,
+      "acc_norm": 0.20679012345679013,
+      "acc_norm_stderr": 0.022535006705942818
+    },
+    "sciq": {
+      "acc": 0.9,
+      "acc_stderr": 0.009491579957525023,
+      "acc_norm": 0.845,
+      "acc_norm_stderr": 0.011450157470799475
+    },
+    "hendrycksTest-medical_genetics": {
+      "acc": 0.31,
+      "acc_stderr": 0.04648231987117316,
+      "acc_norm": 0.33,
+      "acc_norm_stderr": 0.04725815626252605
+    },
+    "hendrycksTest-sociology": {
+      "acc": 0.24378109452736318,
+      "acc_stderr": 0.030360490154014652,
+      "acc_norm": 0.24875621890547264,
+      "acc_norm_stderr": 0.030567675938916714
+    },
+    "arc_challenge": {
+      "acc": 0.302901023890785,
+      "acc_stderr": 0.013428241573185349,
+      "acc_norm": 0.33532423208191126,
+      "acc_norm_stderr": 0.013796182947785564
+    },
+    "hendrycksTest-high_school_european_history": {
+      "acc": 0.2727272727272727,
+      "acc_stderr": 0.03477691162163659,
+      "acc_norm": 0.2606060606060606,
+      "acc_norm_stderr": 0.03427743175816524
+    },
+    "hendrycksTest-electrical_engineering": {
+      "acc": 0.2827586206896552,
+      "acc_stderr": 0.037528339580033376,
+      "acc_norm": 0.3103448275862069,
+      "acc_norm_stderr": 0.03855289616378948
+    },
+    "hendrycksTest-high_school_macroeconomics": {
+      "acc": 0.28974358974358977,
+      "acc_stderr": 0.023000628243687954,
+      "acc_norm": 0.26153846153846155,
+      "acc_norm_stderr": 0.022282141204204423
+    },
+    "hendrycksTest-human_aging": {
+      "acc": 0.24663677130044842,
+      "acc_stderr": 0.028930413120910888,
+      "acc_norm": 0.23766816143497757,
+      "acc_norm_stderr": 0.028568079464714267
+    },
+    "hendrycksTest-public_relations": {
+      "acc": 0.3,
+      "acc_stderr": 0.04389311454644286,
+      "acc_norm": 0.19090909090909092,
+      "acc_norm_stderr": 0.03764425585984926
+    },
+    "hendrycksTest-professional_law": {
+      "acc": 0.2470664928292047,
+      "acc_stderr": 0.011015752255279329,
+      "acc_norm": 0.2796610169491525,
+      "acc_norm_stderr": 0.011463397393861968
+    },
+    "hendrycksTest-computer_security": {
+      "acc": 0.26,
+      "acc_stderr": 0.044084400227680794,
+      "acc_norm": 0.36,
+      "acc_norm_stderr": 0.048241815132442176
+    },
+    "hendrycksTest-abstract_algebra": {
+      "acc": 0.27,
+      "acc_stderr": 0.0446196043338474,
+      "acc_norm": 0.25,
+      "acc_norm_stderr": 0.04351941398892446
+    },
+    "hendrycksTest-high_school_microeconomics": {
+      "acc": 0.25630252100840334,
+      "acc_stderr": 0.02835962087053395,
+      "acc_norm": 0.3277310924369748,
+      "acc_norm_stderr": 0.030489911417673227
+    },
+    "hendrycksTest-high_school_statistics": {
+      "acc": 0.3333333333333333,
+      "acc_stderr": 0.0321495214780275,
+      "acc_norm": 0.3194444444444444,
+      "acc_norm_stderr": 0.03179876342176851
+    },
+    "hendrycksTest-world_religions": {
+      "acc": 0.3216374269005848,
+      "acc_stderr": 0.03582529442573122,
+      "acc_norm": 0.38596491228070173,
+      "acc_norm_stderr": 0.03733756969066164
+    },
+    "hendrycksTest-us_foreign_policy": {
+      "acc": 0.29,
+      "acc_stderr": 0.04560480215720684,
+      "acc_norm": 0.28,
+      "acc_norm_stderr": 0.04512608598542127
+    },
+    "hendrycksTest-formal_logic": {
+      "acc": 0.2857142857142857,
+      "acc_stderr": 0.04040610178208841,
+      "acc_norm": 0.2619047619047619,
+      "acc_norm_stderr": 0.03932537680392869
+    },
+    "hendrycksTest-high_school_geography": {
+      "acc": 0.2222222222222222,
+      "acc_stderr": 0.029620227874790465,
+      "acc_norm": 0.32323232323232326,
+      "acc_norm_stderr": 0.033322999210706444
+    },
+    "hendrycksTest-jurisprudence": {
+      "acc": 0.25,
+      "acc_stderr": 0.04186091791394607,
+      "acc_norm": 0.4351851851851852,
+      "acc_norm_stderr": 0.04792898170907061
+    },
+    "hendrycksTest-logical_fallacies": {
+      "acc": 0.2085889570552147,
+      "acc_stderr": 0.031921934489347235,
+      "acc_norm": 0.3067484662576687,
+      "acc_norm_stderr": 0.036230899157241474
+    },
+    "hendrycksTest-business_ethics": {
+      "acc": 0.3,
+      "acc_stderr": 0.046056618647183814,
+      "acc_norm": 0.3,
+      "acc_norm_stderr": 0.046056618647183814
+    },
+    "hendrycksTest-college_mathematics": {
+      "acc": 0.23,
+      "acc_stderr": 0.04229525846816505,
+      "acc_norm": 0.32,
+      "acc_norm_stderr": 0.04688261722621504
+    },
+    "hendrycksTest-machine_learning": {
+      "acc": 0.26785714285714285,
+      "acc_stderr": 0.04203277291467763,
+      "acc_norm": 0.24107142857142858,
+      "acc_norm_stderr": 0.040598672469526885
+    },
+    "hendrycksTest-high_school_us_history": {
+      "acc": 0.2647058823529412,
+      "acc_stderr": 0.03096451792692341,
+      "acc_norm": 0.23529411764705882,
+      "acc_norm_stderr": 0.029771775228145635
+    },
+    "logiqa": {
+      "acc": 0.20276497695852536,
+      "acc_stderr": 0.015770046635584564,
+      "acc_norm": 0.282642089093702,
+      "acc_norm_stderr": 0.017661585370360618
+    },
+    "hendrycksTest-high_school_mathematics": {
+      "acc": 0.25925925925925924,
+      "acc_stderr": 0.026719240783712166,
+      "acc_norm": 0.31851851851851853,
+      "acc_norm_stderr": 0.02840653309060846
+    },
+    "hendrycksTest-college_medicine": {
+      "acc": 0.2138728323699422,
+      "acc_stderr": 0.03126511206173042,
+      "acc_norm": 0.26011560693641617,
+      "acc_norm_stderr": 0.03345036916788992
+    },
+    "lambada_openai": {
+      "ppl": 6.619609321132733,
+      "ppl_stderr": 0.1762529804582454,
+      "acc": 0.5761692218125364,
+      "acc_stderr": 0.006884673454916894
+    },
+    "hendrycksTest-college_chemistry": {
+      "acc": 0.3,
+      "acc_stderr": 0.046056618647183814,
+      "acc_norm": 0.33,
+      "acc_norm_stderr": 0.04725815626252606
+    },
+    "hendrycksTest-human_sexuality": {
+      "acc": 0.33587786259541985,
+      "acc_stderr": 0.041423137719966634,
+      "acc_norm": 0.29770992366412213,
+      "acc_norm_stderr": 0.040103589424622034
+    },
+    "hendrycksTest-virology": {
+      "acc": 0.3493975903614458,
+      "acc_stderr": 0.037117251907407486,
+      "acc_norm": 0.2891566265060241,
+      "acc_norm_stderr": 0.035294868015111155
+    },
+    "hendrycksTest-moral_disputes": {
+      "acc": 0.24855491329479767,
+      "acc_stderr": 0.023267528432100174,
+      "acc_norm": 0.3208092485549133,
+      "acc_norm_stderr": 0.025131000233647897
+    },
+    "hendrycksTest-high_school_chemistry": {
+      "acc": 0.22660098522167488,
+      "acc_stderr": 0.029454863835292982,
+      "acc_norm": 0.2857142857142857,
+      "acc_norm_stderr": 0.03178529710642749
+    },
+    "hendrycksTest-security_studies": {
+      "acc": 0.27755102040816326,
+      "acc_stderr": 0.02866685779027465,
+      "acc_norm": 0.3224489795918367,
+      "acc_norm_stderr": 0.029923100563683906
+    },
+    "hendrycksTest-moral_scenarios": {
+      "acc": 0.2446927374301676,
+      "acc_stderr": 0.014378169884098433,
+      "acc_norm": 0.27262569832402234,
+      "acc_norm_stderr": 0.014893391735249588
+    },
+    "hendrycksTest-high_school_computer_science": {
+      "acc": 0.25,
+      "acc_stderr": 0.04351941398892446,
+      "acc_norm": 0.26,
+      "acc_norm_stderr": 0.04408440022768079
+    },
+    "hendrycksTest-high_school_psychology": {
+      "acc": 0.26605504587155965,
+      "acc_stderr": 0.01894602232222559,
+      "acc_norm": 0.25871559633027524,
+      "acc_norm_stderr": 0.01877605231961962
+    },
+    "hendrycksTest-anatomy": {
+      "acc": 0.2518518518518518,
+      "acc_stderr": 0.03749850709174022,
+      "acc_norm": 0.23703703703703705,
+      "acc_norm_stderr": 0.03673731683969506
+    },
+    "hendrycksTest-miscellaneous": {
+      "acc": 0.29246487867177523,
+      "acc_stderr": 0.016267000684598656,
+      "acc_norm": 0.2567049808429119,
+      "acc_norm_stderr": 0.015620480263064526
+    },
+    "hendrycksTest-professional_psychology": {
+      "acc": 0.2549019607843137,
+      "acc_stderr": 0.017630827375148383,
+      "acc_norm": 0.24836601307189543,
+      "acc_norm_stderr": 0.01747948700136476
+    },
+    "hendrycksTest-professional_accounting": {
+      "acc": 0.22340425531914893,
+      "acc_stderr": 0.024847921358063962,
+      "acc_norm": 0.26595744680851063,
+      "acc_norm_stderr": 0.026358065698880592
+    },
+    "hendrycksTest-conceptual_physics": {
+      "acc": 0.2127659574468085,
+      "acc_stderr": 0.026754391348039766,
+      "acc_norm": 0.19148936170212766,
+      "acc_norm_stderr": 0.0257221499926378
+    },
+    "hendrycksTest-astronomy": {
+      "acc": 0.29605263157894735,
+      "acc_stderr": 0.03715062154998904,
+      "acc_norm": 0.3355263157894737,
+      "acc_norm_stderr": 0.03842498559395271
+    },
+    "hendrycksTest-philosophy": {
+      "acc": 0.21543408360128619,
+      "acc_stderr": 0.02335022547547142,
+      "acc_norm": 0.31511254019292606,
+      "acc_norm_stderr": 0.026385273703464485
+    },
+    "hendrycksTest-college_computer_science": {
+      "acc": 0.28,
+      "acc_stderr": 0.045126085985421276,
+      "acc_norm": 0.28,
+      "acc_norm_stderr": 0.04512608598542127
+    },
+    "piqa": {
+      "acc": 0.7263329706202394,
+      "acc_stderr": 0.010402184206229202,
+      "acc_norm": 0.736126224156692,
+      "acc_norm_stderr": 0.010282996367695571
+    },
+    "hendrycksTest-high_school_physics": {
+      "acc": 0.2913907284768212,
+      "acc_stderr": 0.03710185726119995,
+      "acc_norm": 0.26490066225165565,
+      "acc_norm_stderr": 0.036030385453603826
+    },
+    "hendrycksTest-marketing": {
+      "acc": 0.2777777777777778,
+      "acc_stderr": 0.029343114798094486,
+      "acc_norm": 0.3247863247863248,
+      "acc_norm_stderr": 0.03067902276549883
+    },
+    "hendrycksTest-nutrition": {
+      "acc": 0.30718954248366015,
+      "acc_stderr": 0.026415601914389002,
+      "acc_norm": 0.3660130718954248,
+      "acc_norm_stderr": 0.02758281141515962
+    },
+    "hendrycksTest-econometrics": {
+      "acc": 0.2543859649122807,
+      "acc_stderr": 0.04096985139843671,
+      "acc_norm": 0.2807017543859649,
+      "acc_norm_stderr": 0.042270544512322004
+    },
+    "hendrycksTest-high_school_biology": {
+      "acc": 0.26129032258064516,
+      "acc_stderr": 0.024993053397764812,
+      "acc_norm": 0.2838709677419355,
+      "acc_norm_stderr": 0.025649381063029258
+    },
+    "arc_easy": {
+      "acc": 0.6498316498316499,
+      "acc_stderr": 0.009788295410093148,
+      "acc_norm": 0.5732323232323232,
+      "acc_norm_stderr": 0.010149141043955626
+    },
+    "wsc": {
+      "acc": 0.36538461538461536,
+      "acc_stderr": 0.0474473339327792
+    },
+    "hendrycksTest-college_physics": {
+      "acc": 0.23529411764705882,
+      "acc_stderr": 0.04220773659171452,
+      "acc_norm": 0.23529411764705882,
+      "acc_norm_stderr": 0.04220773659171452
+    },
+    "hendrycksTest-international_law": {
+      "acc": 0.21487603305785125,
+      "acc_stderr": 0.03749492448709698,
+      "acc_norm": 0.5041322314049587,
+      "acc_norm_stderr": 0.04564198767432754
+    },
+    "hendrycksTest-college_biology": {
+      "acc": 0.2152777777777778,
+      "acc_stderr": 0.03437079344106133,
+      "acc_norm": 0.2708333333333333,
+      "acc_norm_stderr": 0.03716177437566017
+    },
+    "winogrande": {
+      "acc": 0.6440410418310971,
+      "acc_stderr": 0.013456740656273954
+    },
+    "hendrycksTest-management": {
+      "acc": 0.2621359223300971,
+      "acc_stderr": 0.04354631077260595,
+      "acc_norm": 0.2524271844660194,
+      "acc_norm_stderr": 0.04301250399690877
+    },
+    "hendrycksTest-high_school_government_and_politics": {
+      "acc": 0.27979274611398963,
+      "acc_stderr": 0.03239637046735701,
+      "acc_norm": 0.31088082901554404,
+      "acc_norm_stderr": 0.03340361906276588
+    }
+  },
+  "versions": {
+    "hendrycksTest-professional_medicine": 0,
+    "hendrycksTest-high_school_world_history": 0,
+    "hendrycksTest-elementary_mathematics": 0,
+    "hendrycksTest-clinical_knowledge": 0,
+    "hendrycksTest-global_facts": 0,
+    "hendrycksTest-prehistory": 0,
+    "sciq": 0,
+    "hendrycksTest-medical_genetics": 0,
+    "hendrycksTest-sociology": 0,
+    "arc_challenge": 0,
+    "hendrycksTest-high_school_european_history": 0,
+    "hendrycksTest-electrical_engineering": 0,
+    "hendrycksTest-high_school_macroeconomics": 0,
+    "hendrycksTest-human_aging": 0,
+    "hendrycksTest-public_relations": 0,
+    "hendrycksTest-professional_law": 0,
+    "hendrycksTest-computer_security": 0,
+    "hendrycksTest-abstract_algebra": 0,
+    "hendrycksTest-high_school_microeconomics": 0,
+    "hendrycksTest-high_school_statistics": 0,
+    "hendrycksTest-world_religions": 0,
+    "hendrycksTest-us_foreign_policy": 0,
+    "hendrycksTest-formal_logic": 0,
+    "hendrycksTest-high_school_geography": 0,
+    "hendrycksTest-jurisprudence": 0,
+    "hendrycksTest-logical_fallacies": 0,
+    "hendrycksTest-business_ethics": 0,
+    "hendrycksTest-college_mathematics": 0,
+    "hendrycksTest-machine_learning": 0,
+    "hendrycksTest-high_school_us_history": 0,
+    "logiqa": 0,
+    "hendrycksTest-high_school_mathematics": 0,
+    "hendrycksTest-college_medicine": 0,
+    "lambada_openai": 0,
+    "hendrycksTest-college_chemistry": 0,
+    "hendrycksTest-human_sexuality": 0,
+    "hendrycksTest-virology": 0,
+    "hendrycksTest-moral_disputes": 0,
+    "hendrycksTest-high_school_chemistry": 0,
+    "hendrycksTest-security_studies": 0,
+    "hendrycksTest-moral_scenarios": 0,
+    "hendrycksTest-high_school_computer_science": 0,
+    "hendrycksTest-high_school_psychology": 0,
+    "hendrycksTest-anatomy": 0,
+    "hendrycksTest-miscellaneous": 0,
+    "hendrycksTest-professional_psychology": 0,
+    "hendrycksTest-professional_accounting": 0,
+    "hendrycksTest-conceptual_physics": 0,
+    "hendrycksTest-astronomy": 0,
+    "hendrycksTest-philosophy": 0,
+    "hendrycksTest-college_computer_science": 0,
+    "piqa": 0,
+    "hendrycksTest-high_school_physics": 0,
+    "hendrycksTest-marketing": 0,
+    "hendrycksTest-nutrition": 0,
+    "hendrycksTest-econometrics": 0,
+    "hendrycksTest-high_school_biology": 0,
+    "arc_easy": 0,
+    "wsc": 0,
+    "hendrycksTest-college_physics": 0,
+    "hendrycksTest-international_law": 0,
+    "hendrycksTest-college_biology": 0,
+    "winogrande": 0,
+    "hendrycksTest-management": 0,
+    "hendrycksTest-high_school_government_and_politics": 0
+  },
+  "config": {
+    "model": "hf-causal",
+    "model_args": "pretrained=bigscience/bloom-7b1,use_accelerate=True,device_map_option=sequential,max_memory_per_gpu=40GIB",
+    "num_fewshot": 0,
+    "batch_size": 8,
+    "device": "cuda",
+    "no_cache": false,
+    "limit": null,
+    "bootstrap_iters": 100000,
+    "description_dict": {}
+  }
+}


### PR DESCRIPTION
Adds evaluations for the following [BigScience BLOOM](https://arxiv.org/abs/2211.05100) models with the <samp><kbd>arc_challenge,<wbr />arc_easy,<wbr />lambada_openai,<wbr />logiqa,<wbr />sciq,<wbr />piqa,<wbr />wsc,<wbr />winogrande,<wbr />hendrycksTest*</kbd></samp> [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) task specification.
- [BLOOM-560M](https://huggingface.co/bigscience/bloom-560m)
- [BLOOM-1.1B](https://huggingface.co/bigscience/bloom-1b1)
- [BLOOM-1.7B](https://huggingface.co/bigscience/bloom-1b7)
- [BLOOM-3B](https://huggingface.co/bigscience/bloom-3b)
- [BLOOM-7.1B](https://huggingface.co/bigscience/bloom-7b1)
