### PR TITLE
Update readme to load preshuffled datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ which should output your results.
 
 We provide a tool to view particular portions of the training dataloader used by all models during training, at `utils/batch_viewer.py`.
 
-First, we need to clone the repository
+First, we need to clone the Pythia repository:
 ```
 git clone https://github.com/EleutherAI/pythia
 ```
@@ -191,21 +191,21 @@ pip install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch/
 pip install numpy tqdm huggingface_hub
 ```
 
-Next, we must download the appropriate dataset. We provide preshuffled versions of duped and deduped pile. Download the appropriate one using `huggingface-cli`
+Next, we must download the appropriate dataset. We provide preshuffled versions of the duped and deduped pile. Download the appropriate one using Huggingface's utilities as follows:
 
-> Make Sure to replace `path/to/local/folder/` and `path/to/merged/folder/` to appropriate paths where you intend to save datasets downloaded from huggingface
+> Tip: Make sure to replace `path/to/local/folder/` and `path/to/merged/folder/` to the appropriate local paths where you intend to save datasets downloaded from Huggingface.
 - To download standard version, use 
   ```py
   from huggingface_hub import hf_hub_download
   hf_hub_download(repo_id="EleutherAI/pile-standard-pythia-preshuffled", repo_type="dataset", cache_dir="path/to/local/folder")
   ```
-- To download deduped version, use
+- To download the deduped version, use
   ```py
   from huggingface_hub import hf_hub_download
   hf_hub_download(repo_id="EleutherAI/pile-standard-pythia-preshuffled", repo_type="dataset", cache_dir="path/to/local/folder")
   ```
 
-You can now merge the files by using `utils/unshard_mmap.py`
+You can now merge the files by using the script `utils/unshard_mmap.py` : 
 
 ```sh
 python3 utils/unshard_mmap.py --input_file "path/to/local/folder/document-00000-of-00020.bin" --num_shards 21 --output_dir "path/to/merged/folder/"

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ pip install numpy tqdm huggingface_hub
 
 Next, we must download the appropriate dataset. We provide preshuffled versions of the duped and deduped pile. Download the appropriate one using Huggingface's utilities as follows:
 
-> Tip: Make sure to replace `path/to/local/folder/` and `path/to/merged/folder/` to the appropriate local paths where you intend to save datasets downloaded from Huggingface.
+> Tip: Make sure to replace `path/to/*` to appropriate paths where you intend to save datasets downloaded from Huggingface.
 - To download standard version, use 
   ```py
   from huggingface_hub import hf_hub_download
@@ -223,11 +223,22 @@ python3 utils/batch_viewer.py \
   --start_iteration 0 \
   --end_iteration 1000 \
   --load_path path/to/merged/folder/document \
-  --save_path .../.../.../... \
+  --save_path path/to/save/folder/ \
   --conf_dir utils/dummy_config.yml 
 ```
 
 This will save a separate file containing all the indicies as a numpy array. 
+
+You can now load this using numpy as 
+
+```py
+import numpy as np
+
+indicies = np.load("path/to/save/folder/indicies.npy")
+```
+
+These indicies contain tokenized sequences of integers of size (None, 2049), where an integer corresponds to a unique token index.
+Note that documents are concatenated and saperated by an `EOD` token. Thus, each sample or batch may not start with an EOD token. During training, target tokens are left shifted by 1. Thus, a model of sequence length 2048 requires 2049 length sequences for training (For more info, refer to [this comment](https://github.com/EleutherAI/pythia/issues/123#issuecomment-1791136253))
 
 # Pythia Paper Replication
 

--- a/predictable-memorization/README.md
+++ b/predictable-memorization/README.md
@@ -3,7 +3,7 @@
 This folder documents our work using Pythia to study memorization of particular sequences in the training dataset, and includes instructions to reproduce our analyses where possible.
 
 ## Reproducing Memorization Results
-The memorization evaluation script `memorization/eval_memorization.py` assumes that you are running the script in a distributed process, ideally in slurm. It also assumes that you are using s3 to load and save pile's preshuffled datasets (refer [here](https://github.com/EleutherAI/pythia/blob/main/README.md#dataset-viewer) for more details on how to download them).
+The memorization evaluation script `memorization/eval_memorization.py` assumes that you are running the script in a distributed process, ideally in slurm. It also assumes that you are using s3 to load and save Pythia's preshuffled Pile datasets (refer [here](https://github.com/EleutherAI/pythia/blob/main/README.md#dataset-viewer) for more details on how to download them), though using a local filesystem for the preshuffled datasets is also supported.
 
 If you want to reproduce the evaluation, consider the following steps.
 
@@ -25,11 +25,11 @@ If you want to reproduce the evaluation, consider the following steps.
 
 ## Reproducing Figures
 
-Refer to `memorization/eda.ipynb` for details on replication
+Refer to `memorization/eda.ipynb` for details on replication.
 
 ## Reproducing Scaling Laws Plots
 
-Refer to `memorization/eda.ipynb` for details on replication
+Refer to `memorization/eda.ipynb` for details on replication.
 
 ## Citation Details
 

--- a/predictable-memorization/README.md
+++ b/predictable-memorization/README.md
@@ -3,9 +3,11 @@
 This folder documents our work using Pythia to study memorization of particular sequences in the training dataset, and includes instructions to reproduce our analyses where possible.
 
 ## Reproducing Memorization Results
-The memorization evaluation script `memorization/eval_memorization.py` assumes that you are running the script in a distributed process, ideally in slurm. If you want to reproduce the evaluation, consider the following steps.
+The memorization evaluation script `memorization/eval_memorization.py` assumes that you are running the script in a distributed process, ideally in slurm. It also assumes that you are using s3 to load and save pile's preshuffled datasets (refer [here](https://github.com/EleutherAI/pythia/blob/main/README.md#dataset-viewer) for more details on how to download them).
 
-1. Change `prefix` and `idx_path` local variables of `generate_function()` to point to the right document and index path.
+If you want to reproduce the evaluation, consider the following steps.
+
+1. Change `prefix` local variable of `generate_function()` to point to the right document path.
 
 2. If you are not using [Slurm](https://slurm.schedmd.com/documentation.html), You need to change global variables inside the script, like `RANK` and `NUM_PROCS` (world size) to point to the right environment variables.
 
@@ -23,9 +25,11 @@ The memorization evaluation script `memorization/eval_memorization.py` assumes t
 
 ## Reproducing Figures
 
+Refer to `memorization/eda.ipynb` for details on replication
 
 ## Reproducing Scaling Laws Plots
 
+Refer to `memorization/eda.ipynb` for details on replication
 
 ## Citation Details
 

--- a/utils/batch_viewer.py
+++ b/utils/batch_viewer.py
@@ -39,6 +39,6 @@ if __name__ == '__main__':
     filename = os.path.join(args.save_path, "indicies.npy")
 
     dataset = MMapIndexedDataset(args.load_path, skip_warmup = True)
-    indicies = dataset[args.start_iteration: args.end_iteration + 1]
+    indicies = dataset[args.start_iteration*1024: args.end_iteration*1024 + 1]
     np.save(filename, indicies)
 

--- a/utils/mmap_dataset.py
+++ b/utils/mmap_dataset.py
@@ -171,6 +171,9 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
         self._index = None
         self._bin_buffer = None
 
+        if path.endswith(".bin") or path.endswith(".idx"):
+            path = path[:-4]
+
         self._do_init(path, skip_warmup)
 
     def __getstate__(self):


### PR DESCRIPTION
Added readme to support preshuffled datasets, available now in [standard](https://huggingface.co/datasets/EleutherAI/pile-standard-pythia-preshuffled) and [deduped](https://huggingface.co/datasets/EleutherAI/pile-deduped-pythia-preshuffled) flavours