### PR TITLE
include full 'end_iteration' batch

### DIFF
--- a/utils/batch_viewer.py
+++ b/utils/batch_viewer.py
@@ -39,6 +39,6 @@ if __name__ == '__main__':
     filename = os.path.join(args.save_path, "indicies.npy")
 
     dataset = MMapIndexedDataset(args.load_path, skip_warmup = True)
-    indicies = dataset[args.start_iteration*1024: args.end_iteration*1024 + 1]
+    indicies = dataset[args.start_iteration*1024: (args.end_iteration+1)*1024]
     np.save(filename, indicies)
 


### PR DESCRIPTION
The slices upper bound captured only the first sample of the final batch (1/1024). 
Changing the bound to `(end_iteration + 1) * 1024` ensures that the full last batch is returned.

Fixes #186