### PR TITLE
Fix int overflow in MMapIndexedDataset size computation

### DIFF
--- a/utils/mmap_dataset.py
+++ b/utils/mmap_dataset.py
@@ -17,10 +17,8 @@
 #   the dataset are always of sequence length 2049
 
 import os
-import shutil
 import struct
 from functools import lru_cache
-from itertools import accumulate
 
 import numpy as np
 import torch
@@ -223,8 +221,7 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
                 raise ValueError("Slices into indexed_dataset must be contiguous")
             ptr = self._index._pointers[start]
             sizes = self._index._sizes[idx]
-            offsets = list(accumulate(sizes))
-            total_size = sum(sizes)
+            total_size = sizes.sum(dtype=np.int64)
             np_array = np.frombuffer(
                 self._bin_buffer, dtype=self._index.dtype, count=total_size, offset=ptr
             )


### PR DESCRIPTION
## Current Behavior

Using the ```utils/batch_viewer.py``` script can lead to integer overflows in the file ```utils/mmap_dataset.py```.
For example, the following usage of the batch viewer
```sh
python3 utils/batch_viewer.py --start_iteration 40000 --end_iteration 42000 --load_path your_load_path --save_path your_save_path 
```
results in an ```indicies.npy``` file that is significantly larger than the expected 7.9GB and prints the following warning:
```
/home/user/pythia/utils/mmap_dataset.py:226: RuntimeWarning: overflow encountered in scalar add
  offsets = list(accumulate(sizes))
/home/user/pythia/utils/mmap_dataset.py:227: RuntimeWarning: overflow encountered in scalar add
  total_size = sum(sizes)
 ```
 
 ## Proposed Solution
 
 This issue can be fixed by casting the data to int64 during the summation:
 ```diff
 - total_size = sum(sizes)
 + total_size = sizes.sum(dtype=np.int64)
 ``` 
 I have also removed the unused ```offsets``` variable and unused import statements.